### PR TITLE
fix clang++ segmentation fault

### DIFF
--- a/R-proj/src/spectrahedron.cpp
+++ b/R-proj/src/spectrahedron.cpp
@@ -15,8 +15,8 @@
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
-#include "LMI.h"
-#include "spectrahedron.h"
+#include "convex_bodies/spectrahedra/LMI.h"
+#include "convex_bodies/spectrahedra/spectrahedron.h"
 #include "SDPAFormatManager.h"
 
 //' Write a SDPA format file

--- a/include/SDPAFormatManager.h
+++ b/include/SDPAFormatManager.h
@@ -10,7 +10,7 @@
 #ifndef VOLESTI_SDPA_FORMAT_MANAGER_H
 #define VOLESTI_SDPA_FORMAT_MANAGER_H
 
-#include "spectrahedron.h"
+#include "convex_bodies/spectrahedra/spectrahedron.h"
 
 #include <string>
 #include <sstream>

--- a/include/convex_bodies/spectrahedra/LMI.h
+++ b/include/convex_bodies/spectrahedra/LMI.h
@@ -48,8 +48,8 @@ class LMI<NT, Eigen::Matrix<NT,Eigen::Dynamic,Eigen::Dynamic>, Eigen::Matrix<NT,
 
     /// Creates A LMI object
     /// \param[in] matrices The matrices A_0, A_i
-    LMI(std::vector<MT>& matrices) {
-        typename std::vector<MT>::iterator it = matrices.begin();
+    LMI(std::vector<MT> const & matrices) {
+        typename std::vector<MT>::const_iterator it = matrices.begin();
 
         while (it!=matrices.end()) {
             this->matrices.push_back(*it);

--- a/include/convex_bodies/spectrahedra/spectrahedron.h
+++ b/include/convex_bodies/spectrahedra/spectrahedron.h
@@ -43,7 +43,7 @@ public:
     }
 
     /// \return The LMI describing this spectrahedron
-    LMI<NT, MT, VT> getLMI() const {
+    LMI<NT, MT, VT> const & getLMI() const {
         return lmi;
     }
 


### PR DESCRIPTION
There was a problem with clang when accessing elements of vector spectrahedron.getLMI().getMatrices()

- getMatrices() returns std::vector const &. The fix was to make Spectrahedron class method getLMI() return LMI const &
- also make LMI constructor take parameter const &, not just &