### PR TITLE
Fix print issue while initializing hpolytope

### DIFF
--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -131,7 +131,10 @@ public:
         for (unsigned int i = 1; i < Pin.size(); i++) {
             b(i - 1) = Pin[i][0];
             for (unsigned int j = 1; j < _d + 1; j++) {
-                A(i - 1, j - 1) = -Pin[i][j];
+                if(Pin[i][j]>1e-9 || Pin[i][j]<-(1e-9) )
+                    A(i - 1, j - 1) = -Pin[i][j];
+                else
+                    A(i - 1, j - 1) = Pin[i][j];
             }
         }
     }

--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -131,10 +131,12 @@ public:
         for (unsigned int i = 1; i < Pin.size(); i++) {
             b(i - 1) = Pin[i][0];
             for (unsigned int j = 1; j < _d + 1; j++) {
-                if(Pin[i][j]>1e-9 || Pin[i][j]<-(1e-9) )
+                if(Pin[i][j] != 0){
                     A(i - 1, j - 1) = -Pin[i][j];
-                else
-                    A(i - 1, j - 1) = Pin[i][j];
+                }
+                else{
+                    A(i - 1, j - 1) = 0;
+                }
             }
         }
     }


### PR DESCRIPTION
Currently, if there are 0 entries in ine file for initializing, then if the hpolytope is printed, it return -0 entries.
Fixes #110 