### PR TITLE
Replacing boost::ublas with Eigen

### DIFF
--- a/external/minimum_ellipsoid/khach.h
+++ b/external/minimum_ellipsoid/khach.h
@@ -57,7 +57,6 @@
   bool InvertMatrix(const MT<T> &input,
                     MT<T> &inverse)
   {
-    inverse.setIdentity(input.rows(), input.cols());
     inverse = input.inverse();
     return !is_nan(inverse);
   }
@@ -84,7 +83,7 @@
 
   inline void genDiag(const VT<double> &p, MT<double> &res)
   {
-    res.setZero();
+    res.setZero(p.size(), p.size());
 
     for(size_t i=0; i<p.size(); ++i)
     {
@@ -150,7 +149,7 @@
     PN.noalias() = dp * A.transpose();
     PN = A * PN;
 
-    MT<double> M2;
+    VT<double> M2;
     M2.noalias() = A * p;
     
     MT<double> M3;
@@ -158,7 +157,7 @@
 
     MT<double> invert(PN.rows(), PN.cols());
     InvertLP(PN- M3, invert);
-    Q = 1.0/d * invert;
+    Q.noalias() = (invert/d);
     c.noalias() = A * p;
 
   }

--- a/external/minimum_ellipsoid/khach.h
+++ b/external/minimum_ellipsoid/khach.h
@@ -57,9 +57,9 @@
   bool InvertMatrix(const MT<T> &input,
                     MT<T> &inverse)
   {
+    inverse.setIdentity(input.rows(), input.cols());
     inverse = input.inverse();
     return !is_nan(inverse);
-    // return true;
   }
 
 
@@ -86,7 +86,7 @@
   {
     res.setZero();
 
-    for(size_t i=0; i<p.rows(); ++i)
+    for(size_t i=0; i<p.size(); ++i)
     {
       res(i,i)=p(i);
     }
@@ -154,7 +154,7 @@
     M2.noalias() = A * p;
     
     MT<double> M3;
-    M3.noalias() = M2 * M2;
+    M3.noalias() = M2 * M2.transpose();
 
     MT<double> invert(PN.rows(), PN.cols());
     InvertLP(PN- M3, invert);

--- a/include/convex_bodies/vpolytope.h
+++ b/include/convex_bodies/vpolytope.h
@@ -349,7 +349,7 @@ public:
             center = get_mean_of_vertices();
         } else {
 
-            boost::numeric::ublas::matrix<double> Ap(_d,randPoints.size());
+            MT Ap(_d,randPoints.size());
             typename std::list<Point>::iterator rpit=randPoints.begin();
 
             unsigned int i, j = 0;
@@ -361,9 +361,10 @@ public:
                     point_data++;
                 }
             }
-            boost::numeric::ublas::matrix<double> Q(_d, _d);
-            boost::numeric::ublas::vector<double> c2(_d);
+            MT Q(_d, _d);
+            VT c2(_d);
             size_t w=1000;
+            
             KhachiyanAlgo(Ap,0.01,w,Q,c2); // call Khachiyan algorithm
 
             //Get ellipsoid matrix and center as Eigen objects

--- a/include/preprocess/min_sampling_covering_ellipsoid_rounding.hpp
+++ b/include/preprocess/min_sampling_covering_ellipsoid_rounding.hpp
@@ -64,7 +64,7 @@ std::tuple<MT, VT, NT> min_sampling_covering_ellipsoid_rounding(Polytope &P,
         }
 
         // Store points in a matrix to call Khachiyan algorithm for the minimum volume enclosing ellipsoid
-        boost::numeric::ublas::matrix<double> Ap(d, randPoints.size());
+        MT Ap(d, randPoints.size());
         typename std::list<Point>::iterator rpit=randPoints.begin();
 
         j = 0;
@@ -73,8 +73,8 @@ std::tuple<MT, VT, NT> min_sampling_covering_ellipsoid_rounding(Polytope &P,
                 Ap(i,j)=double((*rpit)[i]);
             }
         }
-        boost::numeric::ublas::matrix<double> Q(d,d); //TODO: remove dependence on ublas and copy to eigen
-        boost::numeric::ublas::vector<double> c2(d);
+        MT Q(d,d); //TODO: remove dependence on ublas and copy to eigen
+        VT c2(d);
         size_t w=1000;
         KhachiyanAlgo(Ap,0.01,w,Q,c2); // call Khachiyan algorithm
 


### PR DESCRIPTION
This PR is for replacing boost::ublas with Eigen from the minimum volume ellipsoid as mentioned in #103.
Currently, only "volume_cb_uniform_zonotype" test case is failing. I am debugging how to fix that, meanwhile if anyone else is able to find a bug, please let me know. 