### PR TITLE
Exclude lpsolve from python interface

### DIFF
--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -16,11 +16,14 @@
 #include <iostream>
 #include <Eigen/Eigen>
 #include "preprocess/max_inscribed_ball.hpp"
-#include "lp_oracles/solve_lp.h"
+#ifndef VOLESTIPY
+    #include "lp_oracles/solve_lp.h"
+#endif
+
 
 
 // check if an Eigen vector contains NaN or infinite values
-/*template <typename VT>
+template <typename VT>
 bool is_inner_point_nan_inf(VT const& p)
 {
     typedef Eigen::Array<bool, Eigen::Dynamic, 1> VTint;
@@ -30,7 +33,7 @@ bool is_inner_point_nan_inf(VT const& p)
             return true;
         }
     }
-}*/
+}
 
 //min and max values for the Hit and Run functions
 // H-polytope class
@@ -97,26 +100,29 @@ public:
     //Use LpSolve library
     std::pair<Point, NT> ComputeInnerBall()
     {
-        normalize();
-        _inner_ball = ComputeChebychevBall<NT, Point>(A, b); // use lpsolve library
+       normalize();
+        #ifndef VOLESTIPY
+            _inner_ball = ComputeChebychevBall<NT, Point>(A, b); // use lpsolve library
+        #else
 
-        /*if (_inner_ball.second < 0.0) {
+            if (_inner_ball.second < 0.0) {
 
-            NT const tol = 0.00000001;
-            std::tuple<VT, NT, bool> inner_ball = max_inscribed_ball(A, b, 150, tol);
+                NT const tol = 0.00000001;
+                std::tuple<VT, NT, bool> inner_ball = max_inscribed_ball(A, b, 150, tol);
 
-            // check if the solution is feasible
-            if (is_in(Point(std::get<0>(inner_ball))) == 0 || std::get<1>(inner_ball) < NT(0) ||
-                std::isnan(std::get<1>(inner_ball)) || std::isinf(std::get<1>(inner_ball)) ||
-                !std::get<2>(inner_ball) || is_inner_point_nan_inf(std::get<0>(inner_ball)))
-            {
-                _inner_ball.second = -1.0;
-            } else
-            {
-                _inner_ball.first = Point(std::get<0>(inner_ball));
-                _inner_ball.second = std::get<1>(inner_ball);
+                // check if the solution is feasible
+                if (is_in(Point(std::get<0>(inner_ball))) == 0 || std::get<1>(inner_ball) < NT(0) ||
+                    std::isnan(std::get<1>(inner_ball)) || std::isinf(std::get<1>(inner_ball)) ||
+                    !std::get<2>(inner_ball) || is_inner_point_nan_inf(std::get<0>(inner_ball)))
+                {
+                    _inner_ball.second = -1.0;
+                } else
+                {
+                    _inner_ball.first = Point(std::get<0>(inner_ball));
+                    _inner_ball.second = std::get<1>(inner_ball);
+                }
             }
-        }*/
+        #endif
 
         return _inner_ball;
     }

--- a/include/random_walks/gaussian_cdhr_walk.hpp
+++ b/include/random_walks/gaussian_cdhr_walk.hpp
@@ -9,6 +9,7 @@
 #define RANDOM_WALKS_GAUSSIAN_CDHR_WALK_HPP
 
 #include "generators/boost_random_number_generator.hpp"
+#include "sampling/sphere.hpp"
 #include "random_walks/gaussian_helpers.hpp"
 
 // Pick a point from the distribution exp(-a_i||x||^2) on the coordinate chord

--- a/include/random_walks/gaussian_cdhr_walk.hpp
+++ b/include/random_walks/gaussian_cdhr_walk.hpp
@@ -8,8 +8,8 @@
 #ifndef RANDOM_WALKS_GAUSSIAN_CDHR_WALK_HPP
 #define RANDOM_WALKS_GAUSSIAN_CDHR_WALK_HPP
 
-#include "generators/boost_random_number_generator.hpp"
 #include "sampling/sphere.hpp"
+#include "generators/boost_random_number_generator.hpp"
 #include "random_walks/gaussian_helpers.hpp"
 
 // Pick a point from the distribution exp(-a_i||x||^2) on the coordinate chord

--- a/include/random_walks/gaussian_rdhr_walk.hpp
+++ b/include/random_walks/gaussian_rdhr_walk.hpp
@@ -10,8 +10,9 @@
 #ifndef RANDOM_WALKS_GAUSSIAN_RDHR_WALK_HPP
 #define RANDOM_WALKS_GAUSSIAN_RDHR_WALK_HPP
 
-#include "generators/boost_random_number_generator.hpp"
 #include "random_walks/gaussian_helpers.hpp"
+#include "generators/boost_random_number_generator.hpp"
+
 
 // Pick a point from the distribution exp(-a_i||x||^2) on the chord
 template

--- a/include/random_walks/random_walks.hpp
+++ b/include/random_walks/random_walks.hpp
@@ -20,7 +20,9 @@
 #include "random_walks/uniform_john_walk.hpp"
 #include "random_walks/uniform_vaidya_walk.hpp"
 #include "random_walks/uniform_accelerated_billiard_walk.hpp"
-#include "random_walks/hamiltonian_monte_carlo_walk.hpp"
-#include "random_walks/langevin_walk.hpp"
+#ifndef VOLESTIPY
+    #include "random_walks/hamiltonian_monte_carlo_walk.hpp"
+    #include "random_walks/langevin_walk.hpp"
+#endif
 
 #endif // RANDOM_WALKS_RANDOM_WALKS_HPP

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -10,13 +10,7 @@
 #ifndef RANDOM_WALKS_ACCELERATED_IMPROVED_BILLIARD_WALK_HPP
 #define RANDOM_WALKS_ACCELERATED_IMPROVED_BILLIARD_WALK_HPP
 
-#include "convex_bodies/ball.h"
-#include "convex_bodies/ballintersectconvex.h"
-#include "convex_bodies/hpolytope.h"
-#include "convex_bodies/vpolytope.h"
-#include "convex_bodies/vpolyintersectvpoly.h"
-#include "convex_bodies/zpolytope.h"
-#include "convex_bodies/zonoIntersecthpoly.h"
+#include "sampling/sphere.hpp"
 
 
 // Billiard walk which accelarates each step for uniform distribution

--- a/include/random_walks/uniform_billiard_walk.hpp
+++ b/include/random_walks/uniform_billiard_walk.hpp
@@ -21,9 +21,9 @@
     #include "convex_bodies/zpolytope.h"
     #include "convex_bodies/zonoIntersecthpoly.h"
 #endif
+#include "sampling/sphere.hpp"
 #include "generators/boost_random_number_generator.hpp"
 #include "sampling/random_point_generators.hpp"
-#include "sampling/sphere.hpp"
 #include "volume/sampling_policies.hpp"
 
 template <typename GenericPolytope>

--- a/include/random_walks/uniform_billiard_walk.hpp
+++ b/include/random_walks/uniform_billiard_walk.hpp
@@ -15,10 +15,12 @@
 #include "convex_bodies/ball.h"
 #include "convex_bodies/ballintersectconvex.h"
 #include "convex_bodies/hpolytope.h"
-#include "convex_bodies/vpolytope.h"
-#include "convex_bodies/vpolyintersectvpoly.h"
-#include "convex_bodies/zpolytope.h"
-#include "convex_bodies/zonoIntersecthpoly.h"
+#ifndef VOLESTIPY
+    #include "convex_bodies/vpolytope.h"
+    #include "convex_bodies/vpolyintersectvpoly.h"
+    #include "convex_bodies/zpolytope.h"
+    #include "convex_bodies/zonoIntersecthpoly.h"
+#endif
 #include "generators/boost_random_number_generator.hpp"
 #include "sampling/random_point_generators.hpp"
 #include "sampling/sphere.hpp"
@@ -43,6 +45,7 @@ static NT compute(HPolytope<Point> const& P)
 }
 };
 
+#ifndef VOLESTIPY
 template <typename Point>
 struct compute_diameter<VPolytope<Point>>
 {
@@ -109,17 +112,6 @@ static NT compute(IntersectionOfVpoly<VPolytope<Point>, RandomNumberGenerator> c
 }
 };
 
-template <typename Polytope, typename Point>
-struct compute_diameter<BallIntersectPolytope<Polytope, Ball<Point>>>
-{
-template <typename NT>
-static NT compute(BallIntersectPolytope<Polytope, Ball<Point>> const& P)
-{
-    NT diameter = NT(2) * P.radius();
-    return diameter;
-}
-};
-
 template <typename Point>
 struct compute_diameter<ZonoIntersectHPoly<Zonotope<Point>, HPolytope<Point>>>
 {
@@ -172,6 +164,21 @@ static NT compute(ZonoIntersectHPoly<Zonotope<Point>, HPolytope<Point>> const& P
 }
 };
 
+#endif
+
+template <typename Polytope, typename Point>
+struct compute_diameter<BallIntersectPolytope<Polytope, Ball<Point>>>
+{
+template <typename NT>
+static NT compute(BallIntersectPolytope<Polytope, Ball<Point>> const& P)
+{
+    NT diameter = NT(2) * P.radius();
+    return diameter;
+}
+};
+
+
+
 
 // Billiard walk for uniform distribution
 
@@ -206,11 +213,6 @@ struct Walk
 {
     typedef typename Polytope::PointType Point;
     typedef typename Point::FT NT;
-    typedef HPolytope<Point> Hpolytope;
-    typedef Zonotope<Point> zonotope;
-    typedef ZonoIntersectHPoly <zonotope, Hpolytope> ZonoHPoly;
-    typedef Ball<Point> BallType;
-    typedef BallIntersectPolytope<Polytope,BallType> BallPolytope;
 
     template <typename GenericPolytope>
     Walk(GenericPolytope const& P, Point const& p, RandomNumberGenerator &rng)

--- a/include/random_walks/uniform_cdhr_walk.hpp
+++ b/include/random_walks/uniform_cdhr_walk.hpp
@@ -10,14 +10,7 @@
 #ifndef RANDOM_WALKS_UNIFORM_CDHR_WALK_HPP
 #define RANDOM_WALKS_UNIFORM_CDHR_WALK_HPP
 
-#include "convex_bodies/ball.h"
-#include "convex_bodies/ballintersectconvex.h"
-#include "convex_bodies/hpolytope.h"
-#include "convex_bodies/vpolytope.h"
-#include "convex_bodies/vpolyintersectvpoly.h"
-#include "convex_bodies/zpolytope.h"
-#include "convex_bodies/zonoIntersecthpoly.h"
-#include "generators/boost_random_number_generator.hpp"
+#include "sampling/sphere.hpp"
 
 // random directions hit-and-run walk with uniform target distribution
 struct CDHRWalk

--- a/include/random_walks/uniform_dikin_walk.hpp
+++ b/include/random_walks/uniform_dikin_walk.hpp
@@ -10,13 +10,6 @@
 #ifndef RANDOM_WALKS_DIKIN_WALK_HPP
 #define RANDOM_WALKS_DIKIN_WALK_HPP
 
-#include "convex_bodies/ball.h"
-#include "convex_bodies/ballintersectconvex.h"
-#include "convex_bodies/hpolytope.h"
-#include "convex_bodies/vpolytope.h"
-#include "convex_bodies/vpolyintersectvpoly.h"
-#include "convex_bodies/zpolytope.h"
-#include "convex_bodies/zonoIntersecthpoly.h"
 #include "ellipsoid_walks/dikin_walker.h"
 
 

--- a/include/random_walks/uniform_john_walk.hpp
+++ b/include/random_walks/uniform_john_walk.hpp
@@ -10,13 +10,7 @@
 #ifndef RANDOM_WALKS_JOHN_WALK_HPP
 #define RANDOM_WALKS_JOHN_WALK_HPP
 
-#include "convex_bodies/ball.h"
-#include "convex_bodies/ballintersectconvex.h"
-#include "convex_bodies/hpolytope.h"
-#include "convex_bodies/vpolytope.h"
-#include "convex_bodies/vpolyintersectvpoly.h"
-#include "convex_bodies/zpolytope.h"
-#include "convex_bodies/zonoIntersecthpoly.h"
+
 #include "ellipsoid_walks/john_walker.h"
 
 

--- a/include/random_walks/uniform_rdhr_walk.hpp
+++ b/include/random_walks/uniform_rdhr_walk.hpp
@@ -10,14 +10,8 @@
 #ifndef RANDOM_WALKS_UNIFORM_RDHR_WALK_HPP
 #define RANDOM_WALKS_UNIFORM_RDHR_WALK_HPP
 
-#include "convex_bodies/ball.h"
-#include "convex_bodies/ballintersectconvex.h"
-#include "convex_bodies/hpolytope.h"
-#include "convex_bodies/vpolytope.h"
-#include "convex_bodies/vpolyintersectvpoly.h"
-#include "convex_bodies/zpolytope.h"
-#include "convex_bodies/zonoIntersecthpoly.h"
-#include "generators/boost_random_number_generator.hpp"
+
+#include "sampling/sphere.hpp"
 
 // Random directions hit-and-run walk with uniform target distribution
 

--- a/include/random_walks/uniform_vaidya_walk.hpp
+++ b/include/random_walks/uniform_vaidya_walk.hpp
@@ -10,13 +10,7 @@
 #ifndef RANDOM_WALKS_VAIDYA_WALK_HPP
 #define RANDOM_WALKS_VAIDYA_WALK_HPP
 
-#include "convex_bodies/ball.h"
-#include "convex_bodies/ballintersectconvex.h"
-#include "convex_bodies/hpolytope.h"
-#include "convex_bodies/vpolytope.h"
-#include "convex_bodies/vpolyintersectvpoly.h"
-#include "convex_bodies/zpolytope.h"
-#include "convex_bodies/zonoIntersecthpoly.h"
+
 #include "ellipsoid_walks/vaidya_walker.h"
 
 

--- a/include/volume/volume_cooling_balls.hpp
+++ b/include/volume/volume_cooling_balls.hpp
@@ -15,10 +15,12 @@
 
 #include "cartesian_geom/cartesian_kernel.h"
 #include "convex_bodies/hpolytope.h"
-#include "convex_bodies/vpolytope.h"
-#include "convex_bodies/zpolytope.h"
+#ifndef VOLESTIPY
+    #include "convex_bodies/vpolytope.h"
+    #include "convex_bodies/zpolytope.h"
+    #include "convex_bodies/vpolyintersectvpoly.h"
+#endif
 #include "convex_bodies/ballintersectconvex.h"
-#include "convex_bodies/vpolyintersectvpoly.h"
 #include "sampling/random_point_generators.hpp"
 
 

--- a/include/volume/volume_sequence_of_balls.hpp
+++ b/include/volume/volume_sequence_of_balls.hpp
@@ -24,12 +24,14 @@
 #include "cartesian_geom/cartesian_kernel.h"
 #include "generators/boost_random_number_generator.hpp"
 #include "convex_bodies/hpolytope.h"
-#include "convex_bodies/vpolytope.h"
-#include "convex_bodies/zpolytope.h"
+#ifndef VOLESTIPY
+    #include "convex_bodies/vpolytope.h"
+    #include "convex_bodies/zpolytope.h"
+    #include "convex_bodies/zonoIntersecthpoly.h"
+    #include "convex_bodies/vpolyintersectvpoly.h"
+#endif
 #include "convex_bodies/ball.h"
 #include "convex_bodies/ballintersectconvex.h"
-#include "convex_bodies/zonoIntersecthpoly.h"
-#include "convex_bodies/vpolyintersectvpoly.h"
 #include "random_walks/uniform_cdhr_walk.hpp"
 #include "sampling/random_point_generators.hpp"
 #include "volume/sampling_policies.hpp"

--- a/volestipy/setup.py
+++ b/volestipy/setup.py
@@ -33,17 +33,18 @@ link_args = ['-O3']
 
 extra_volesti_include_dirs = [
 # inside the volestipy directory, there is an extra volestipy folder containing a "include" folder; we add those as included dirs; the bindings.h file is located there
- join("volestipy","include"),
+ join("volestipy", "include"),
 
 # the volesti code uses some external classes. these are located on the "external" directory and we need to add them as well
  join("..","external"),
  join("..","external","minimum_ellipsoid"),
- join("..","external","LPsolve_src","run_headers"),
+ #join("..","external","LPsolve_src","run_headers"),
  join("..","external","boost"),
 
 # we also move back and include and add the directories on the "include" directory (generatorors, random_walks, sampling etc)
  join("..","include"),
  join("..","include","convex"),
+ join("..","include","diagnostics"),
  join("..","include","misc"),
  join("..","include","random_walks"),
  join("..","include","volume"),
@@ -58,14 +59,14 @@ extra_include_dirs = [numpy.get_include()]
 # Extension modules that need to compile against NumPy should use this function to locate the appropriate include directory.
 
 # here I need to check how it is actually included this library
-library_includes = ["lpsolve55"]
+#library_includes = ["lpsolve55"]
 
 ext_module = Extension(
  "volestipy",
  language = "c++",
  sources = src_files,
  include_dirs = extra_include_dirs + extra_volesti_include_dirs,
- libraries = library_includes,
+ #libraries = library_includes,
  extra_compile_args = compiler_args,
  extra_link_args = link_args,
 )

--- a/volestipy/volestipy/include/bindings.h
+++ b/volestipy/volestipy/include/bindings.h
@@ -1,10 +1,6 @@
 #ifndef VOLESTIBINDINGS_H
 #define VOLESTIBINDINGS_H
 
-////// I think we could remove those...
-//#include "Eigen/Eigen"
-//#include "cartesian_kernel.h"
-
 #define VOLESTIPY
 #include <cmath>
 // from SOB volume - exactly the same for CG and CB methods
@@ -12,8 +8,6 @@
 #include <iostream>
 #include "random_walks.hpp"
 #include "random.hpp"
-//#include "misc.h"
-//#include "known_polytope_generators.h"
 #include "random/uniform_int.hpp"
 #include "random/normal_distribution.hpp"
 #include "random/uniform_real_distribution.hpp"
@@ -63,6 +57,12 @@ class HPolytopeCPP{
 
       // the generate_samples() function
       double generate_samples(int walk_len, int number_of_points, int number_of_points_to_burn, bool boundary, 
+       bool cdhr, bool rdhr, bool gaussian, bool set_L, bool accelerated_billiard, bool billiard, bool ball_walk, double a, double L,  
+       bool max_ball, double* inner_point, double radius,
+       double* samples);
+
+      // mmcs_step() impelments a single step of mmcs
+      double mmcs_step(int walk_len, int number_of_points, int number_of_points_to_burn, bool boundary, 
        bool cdhr, bool rdhr, bool gaussian, bool set_L, bool accelerated_billiard, bool billiard, bool ball_walk, double a, double L,  
        bool max_ball, double* inner_point, double radius,
        double* samples);

--- a/volestipy/volestipy/include/bindings.h
+++ b/volestipy/volestipy/include/bindings.h
@@ -5,13 +5,15 @@
 //#include "Eigen/Eigen"
 //#include "cartesian_kernel.h"
 
+#define VOLESTIPY
+#include <cmath>
 // from SOB volume - exactly the same for CG and CB methods
 #include <fstream>
 #include <iostream>
 #include "random_walks.hpp"
 #include "random.hpp"
-#include "misc.h"
-#include "known_polytope_generators.h"
+//#include "misc.h"
+//#include "known_polytope_generators.h"
 #include "random/uniform_int.hpp"
 #include "random/normal_distribution.hpp"
 #include "random/uniform_real_distribution.hpp"

--- a/volestipy/volestipy/src/bindings.cpp
+++ b/volestipy/volestipy/src/bindings.cpp
@@ -24,7 +24,7 @@ HPolytopeCPP::HPolytopeCPP(double *A_np, double *b_np, int n_hyperplanes, int n_
       }
    }
 
-   HP.init(n_variables, A, b);
+   HP = Hpolytope(n_variables, A, b);
    CheBall = HP.ComputeInnerBall();
 }
 // Use a destructor for the HPolytopeCPP object


### PR DESCRIPTION
-- This PR adds a macro `volestipy`. When it is defined the lpsolve is not included.  
-- The python interface does not use the library `lpsolve`.
-- Change the typedef declarations in `\external/minimum_ellipsoid/khach.h` to fix the compiling of python interface