### PR TITLE
Update R-CMD-check-windows.yml

### DIFF
--- a/.github/workflows/R-CMD-check-windows.yml
+++ b/.github/workflows/R-CMD-check-windows.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'devel'}
+#           - {os: windows-latest, r: 'devel'} # Error in library(devtools) : there is no package called ‘devtools’
           - {os: windows-latest, r: 'release'}
 
     env:


### PR DESCRIPTION
Removed `windows-devel` action because of the same error (related to `devtools` not found) that was encountered with `macos-devel`. The fix is similar to the one done in #133, this will fix the failing test case of other PRs (like 
#160, #161).