### PR TITLE
Cran actions fix for ubuntu

### DIFF
--- a/.github/workflows/R-CMD-check-ubuntu.yml
+++ b/.github/workflows/R-CMD-check-ubuntu.yml
@@ -20,18 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # - {os: macOS-latest,   r: 'devel'}
-          # - {os: macOS-latest,   r: 'release'}
-          # - {os: windows-latest, r: 'devel'}
-          # - {os: windows-latest, r: 'release'}
-#          - {os: ubuntu-latest,  r: 'devel'} # error in "Run r-lib/actions/setup-r@master"
-#          - {os: ubuntu-latest,  r: 'release'} ##[error]Error in library(devtools) : there is no package called ‘devtools’
-#          - {os: ubuntu-18.04,   r: 'release'} ##[error]Error in library(devtools) : there is no package called ‘devtools’
-          - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.4',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.3',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+         - {os: ubuntu-latest,  r: 'devel'} # error in "Run r-lib/actions/setup-r@master"
+         - {os: ubuntu-latest,  r: 'release'}
+         - {os: ubuntu-18.04,   r: 'release'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check-ubuntu.yml
+++ b/.github/workflows/R-CMD-check-ubuntu.yml
@@ -22,6 +22,7 @@ jobs:
         config:
          - {os: ubuntu-latest,  r: 'devel'}
          - {os: ubuntu-latest,  r: 'release'}
+         - {os: ubuntu-18.04,   r: 'devel'}
          - {os: ubuntu-18.04,   r: 'release'}
 
     env:

--- a/.github/workflows/R-CMD-check-ubuntu.yml
+++ b/.github/workflows/R-CMD-check-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-         - {os: ubuntu-latest,  r: 'devel'} # error in "Run r-lib/actions/setup-r@master"
+         - {os: ubuntu-latest,  r: 'devel'}
          - {os: ubuntu-latest,  r: 'release'}
          - {os: ubuntu-18.04,   r: 'release'}
 
@@ -31,6 +31,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - run: sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev;
 
       - uses: r-lib/actions/setup-r@master
         with:

--- a/.github/workflows/R-CMD-check-ubuntu.yml
+++ b/.github/workflows/R-CMD-check-ubuntu.yml
@@ -31,7 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev;
+      - run: sudo apt-get update || true;
+             sudo apt install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev;
 
       - uses: r-lib/actions/setup-r@master
         with:


### PR DESCRIPTION
Github actions support for Ubuntu-16.04 stopped yesterday, link: https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/.  
As a result of that, actions with os label `ubuntu-16.04` are no longer running as can be seen on the PRs #176 and #177.   
This PR replaces `ubuntu-16.04` with `ubuntu-18.04` and `ubuntu-latest`. 
