### PR TITLE
Fixed examples and added CI support for compiling examples

### DIFF
--- a/.github/workflows/cmake-gcc.yml
+++ b/.github/workflows/cmake-gcc.yml
@@ -29,6 +29,19 @@ jobs:
                    cd ${GITHUB_WORKSPACE}/examples/"$dir";
                    if [ "$dir" != "optimization_spectrahedra" ]; then
                          cmake . -DLP_SOLVE=/usr/lib/lpsolve/liblpsolve55.so;
+                   else
+                        sudo apt install gfortran;
+                        sudo apt-get install libarpack2-dev;
+                        cd ..;
+                        git clone https://github.com/m-reuter/arpackpp;
+                        cd arpackpp;
+                        ./install-openblas.sh;
+                        ./install-arpack-ng.sh;
+                        cp -R ${GITHUB_WORKSPACE}/examples/arpackpp/external/ ${GITHUB_WORKSPACE}/examples/optimization_spectrahedra/;
+                        cd ..;
+                        rm -rf arpackpp;
+                        cd ${GITHUB_WORKSPACE}/examples/"$dir";
+                        cmake . -DLP_SOLVE=/usr/lib/lpsolve/liblpsolve55.so;
                    fi;
                    cd ../..;
              done;
@@ -38,4 +51,3 @@ jobs:
              cmake -D CMAKE_CXX_COMPILER=${{ matrix.compilers }} -D DISABLE_NLP_ORACLES=ON -D USE_MKL=OFF ../test;
              make;
              ctest --verbose;
-             

--- a/.github/workflows/cmake-gcc.yml
+++ b/.github/workflows/cmake-gcc.yml
@@ -18,12 +18,24 @@ jobs:
             compilers: [g++-5, g++-6, g++-7, g++-8, g++-9, g++-10]
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2.3.4
+      - uses: "actions/setup-python@v2"
       - run: sudo apt-get update || true;
              sudo apt-get install ${{ matrix.compilers }} lp-solve;
+             sudo apt-get install cmake libblkid-dev e2fslibs-dev libboost-all-dev libaudit-dev;
+             sudo apt-get install python3;
+             pip install numpy;
+             for dir in $(ls examples); do
+                   cd ${GITHUB_WORKSPACE}/examples/"$dir";
+                   if [ "$dir" != "optimization_spectrahedra" ]; then
+                         cmake . -DLP_SOLVE=/usr/lib/lpsolve/liblpsolve55.so;
+                   fi;
+                   cd ../..;
+             done;
              rm -rf build;
              mkdir build;
              cd build;
              cmake -D CMAKE_CXX_COMPILER=${{ matrix.compilers }} -D DISABLE_NLP_ORACLES=ON -D USE_MKL=OFF ../test;
              make;
              ctest --verbose;
+             

--- a/examples/EnvelopeProblemSOS/CMakeLists.txt
+++ b/examples/EnvelopeProblemSOS/CMakeLists.txt
@@ -51,9 +51,19 @@ endif ()
 if (USE_OpenMP)
     find_package(OpenMP REQUIRED)
 endif (USE_OpenMP)
-
-find_package(Python2 COMPONENTS Development NumPy)
+find_package(Python3 REQUIRED)
+find_package(Boost REQUIRED)
+find_package(Python3 COMPONENTS Development NumPy)
 add_executable(EnvelopeProblem ${TARGETS})
+
+include("../../external/cmake-files/Eigen.cmake")
+GetEigen()
+
+include("../../external/cmake-files/Boost.cmake")
+GetBoost()
+
+include("../../external/cmake-files/LPSolve.cmake")
+GetLPSolve()
 
 if (NOT BOOST_DIR)
     find_package(Boost 1.67.0 COMPONENTS *boost usr/local/)
@@ -65,7 +75,7 @@ if (NOT BOOST_DIR)
     message(FATAL_ERROR "This program requires the boost library, and will not be compiled. Set with flag -BOOST_DIR.")
 else ()
     target_include_directories(EnvelopeProblem PRIVATE ${BOOST_DIR}
-            ../../include/sos ../../external ${SPDLOG_DIR} ../../include/sos/include ${Python2_INCLUDE_DIRS} ${Python2_NumPy_INCLUDE_DIRS}
+            ../../include/sos ../../external ${SPDLOG_DIR} ../../include/sos/include ${Python3_INCLUDE_DIRS} ${Python3_NumPy_INCLUDE_DIRS}
             ../../../Eigen/eigen
             /usr/local/include
             ${LLVM_INCLUDE_DIRS})
@@ -82,5 +92,5 @@ else ()
     if (USE_OpenMP)
         target_link_directories(EnvelopeProblem PRIVATE ${OPENMP_LIBRARIES})
     endif ()
-    target_link_libraries(EnvelopeProblem Python2::Python Python2::NumPy)
+    target_link_libraries(EnvelopeProblem Python3::Python Python3::NumPy)
 endif ()

--- a/examples/vpolytope-volume/CMakeLists.txt
+++ b/examples/vpolytope-volume/CMakeLists.txt
@@ -106,7 +106,7 @@ else ()
   add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-ldl")
   add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-DBOOST_NO_AUTO_PTR")
 
-  add_executable (vpolytopeVolume vpolytopeVolume.cpp)
-  TARGET_LINK_LIBRARIES(vpolytopeVolume ${LP_SOLVE})
+  add_executable (vpolytopevolume vpolytopevolume.cpp)
+  TARGET_LINK_LIBRARIES(vpolytopevolume ${LP_SOLVE})
 
 endif()


### PR DESCRIPTION
This fixes #193. 

This fixes CMakeLists.txt of `vpolytope-volume` and `EnvelopeProblemSOS`. All examples are now compiling successfully.

I have skipped compiling of `optimization_spectrahedra` in CI, as it required installation of the `openblas`, `lapack`, and `arpack` libraries. So, except that all files are being compiled in Github actions.

