### PR TITLE
Fix undefined behavior in is_inner_point_nan_inf

### DIFF
--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -34,6 +34,7 @@ bool is_inner_point_nan_inf(VT const& p)
             return true;
         }
     }
+    return false;
 }
 
 //min and max values for the Hit and Run functions


### PR DESCRIPTION
Return false if no NaNs or infs are found, because flowing off the end of a non-void (non-coroutine) function is undefined behavior per the C++ standard, e.g., [C++20 draft](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/n4849.pdf#subsection.8.7.3) or [C++11 draft](https://www.open-std.org/Jtc1/sc22/wg21/docs/papers/2011/n3242.pdf#subsection.6.6.3).

In my case with volestipy from Dingo (so this should ultimately make it to the volesti4dingo branch)—which defines DISABLE_LPSOLVE—the call from ComputeInnerBall would (later?) cause Eigen to throw std::bad_alloc from aligned_malloc after trying to allocate some garbage number of bytes.