### PR TITLE
Fix overflow edge case in sequence of balls volume method

### DIFF
--- a/include/volume/volume_sequence_of_balls.hpp
+++ b/include/volume/volume_sequence_of_balls.hpp
@@ -82,7 +82,7 @@ double volume_sequence_of_balls(Polytope const& Pin,
     c = Point(n);
 
     // Scale by number of threads and prevent edge case rnum=0 from producing overflow later
-    rnum = rnum >= n_threads ? rnum/n_threads : 1u;
+    rnum = rnum >= 2*n_threads ? rnum/n_threads : 2u;
     NT vol = NT(0);
 
     // Perform the procedure for a number of threads and then take the average

--- a/include/volume/volume_sequence_of_balls.hpp
+++ b/include/volume/volume_sequence_of_balls.hpp
@@ -81,7 +81,8 @@ double volume_sequence_of_balls(Polytope const& Pin,
     P.shift(c.getCoefficients());
     c = Point(n);
 
-    rnum = rnum/n_threads;
+    // Scale by number of threads and prevent edge case rnum=0 from producing overflow later
+    rnum = rnum >= n_threads ? rnum/n_threads : 1u;
     NT vol = NT(0);
 
     // Perform the procedure for a number of threads and then take the average

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -243,6 +243,8 @@ else ()
   add_test(NAME volume_sob_hpolytope_prod_simplex COMMAND volume_sob_hpolytope -tc=prod_simplex)
   add_test(NAME volume_sob_hpolytope_simplex COMMAND volume_sob_hpolytope -tc=simplex)
   add_test(NAME volume_sob_hpolytope_skinny_cube COMMAND volume_sob_hpolytope -tc=skinny_cube)
+  add_test(NAME volume_sob_hpolytope_cube_overflow COMMAND volume_sob_hpolytope -tc=cube_overflow)
+  set_property(TEST volume_sob_hpolytope_cube_overflow PROPERTY TIMEOUT 1)
 
   add_executable (volume_sob_vpolytope volume_sob_vpolytope.cpp $<TARGET_OBJECTS:test_main>)
   add_test(NAME volume_sob_vpolytope_cube COMMAND volume_sob_vpolytope -tc=cube)

--- a/test/volume_sob_hpolytope.cpp
+++ b/test/volume_sob_hpolytope.cpp
@@ -268,6 +268,18 @@ void call_test_skinny_cube() {
     //test_volume(P, 104857600, 104857600.0);
 }
 
+template <typename NT>
+void call_test_cube_overflow() {
+    typedef Cartesian<NT>    Kernel;
+    typedef typename Kernel::Point    Point;
+    typedef HPolytope<Point> Hpolytope;
+    Hpolytope P;
+
+    std::cout << "--- Testing volume of H-cube1" << std::endl;
+    P = generate_cube<Hpolytope>(1, false);
+    test_volume(P, 2, 2, 2, 2, 2);
+}
+
 
 TEST_CASE("cube") {
     call_test_cube<double>();
@@ -292,4 +304,8 @@ TEST_CASE("simplex") {
 
 TEST_CASE("skinny_cube") {
     call_test_skinny_cube<double>();
+}
+
+TEST_CASE("cube_overflow") {
+    call_test_cube_overflow<double>();
 }


### PR DESCRIPTION
Force rnum>=1, avoiding integer overflow when rnum-1 is passed into RandomPointGenerator::apply a few lines later, which hoovers up RAM and time. This edge case can be observed with a degenerate polytope (I tried a 1D interval) or with extreme choices of `error` and `n_threads`.