### PR TITLE
Fix build issues related to some examples.

### DIFF
--- a/examples/logconcave/CMakeLists.txt
+++ b/examples/logconcave/CMakeLists.txt
@@ -8,13 +8,9 @@
 project( VolEsti )
 
 
-option(DISABLE_NLP_ORACLES "Disable non-linear oracles (used in collocation)" ON)
-option(BUILTIN_EIGEN "Use eigen from ../external" OFF)
-option(USE_MKL "Use MKL library to build eigen" ON)
-
 CMAKE_MINIMUM_REQUIRED(VERSION 2.4.5)
 
-set(MKLROOT $ENV{HOME}/intel/mkl)
+set(MKLROOT /opt/intel/oneapi/mkl/2022.1.0)
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 
 if(COMMAND cmake_policy)
@@ -124,6 +120,7 @@ else ()
   add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-lm")
   add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-ldl")
   add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-DBOOST_NO_AUTO_PTR")
+  add_definitions(${CMAKE_CXX_FLAGS} "-DMKL_ILP64")
   #add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-lgslcblas")
   #add_definitions( "-O3 -lgsl -lm -ldl -lgslcblas" )
 
@@ -145,6 +142,8 @@ else ()
   TARGET_LINK_LIBRARIES(simple_sde ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
   TARGET_LINK_LIBRARIES(simple_uld ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
   TARGET_LINK_LIBRARIES(simple_hmc ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
-
+  TARGET_LINK_LIBRARIES(exponential_exact_hmc ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
+  TARGET_LINK_LIBRARIES(gaussian_exact_hmc ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
+  
 
 endif()

--- a/examples/logconcave/CMakeLists.txt
+++ b/examples/logconcave/CMakeLists.txt
@@ -10,7 +10,7 @@ project( VolEsti )
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.4.5)
 
-set(MKLROOT /opt/intel/oneapi/mkl/2022.1.0)
+set(MKLROOT /opt/intel/oneapi/mkl/latest)
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 
 if(COMMAND cmake_policy)
@@ -77,6 +77,7 @@ if (USE_MKL)
   find_library(BLAS NAME libblas.so PATHS /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu)
   include_directories (BEFORE ${MKLROOT}/include)
   set(PROJECT_LIBS ${BLAS_LIBRARIES})
+  set(MKL_LINK "-L${MKLROOT}/lib -Wl,-rpath,${MKLROOT}/lib -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl")
   add_definitions(-DEIGEN_USE_MKL_ALL)
 endif(USE_MKL)
 
@@ -135,15 +136,15 @@ else ()
 
   #add_executable (adaptive_step_size adaptive_step_size.cpp)
 
-  TARGET_LINK_LIBRARIES(high_dimensional_hmc_rand_poly ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
-  TARGET_LINK_LIBRARIES(high_dimensional_hmc ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
-  #TARGET_LINK_LIBRARIES(adaptive_step_size ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
-  TARGET_LINK_LIBRARIES(simple_ode ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
-  TARGET_LINK_LIBRARIES(simple_sde ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
-  TARGET_LINK_LIBRARIES(simple_uld ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
-  TARGET_LINK_LIBRARIES(simple_hmc ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
-  TARGET_LINK_LIBRARIES(exponential_exact_hmc ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
-  TARGET_LINK_LIBRARIES(gaussian_exact_hmc ${LP_SOLVE} ${BLAS}  "-L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl")
+  TARGET_LINK_LIBRARIES(high_dimensional_hmc_rand_poly ${LP_SOLVE} ${BLAS} ${MKL_LINK} )
+  TARGET_LINK_LIBRARIES(high_dimensional_hmc ${LP_SOLVE} ${BLAS} ${MKL_LINK}  )
+  #TARGET_LINK_LIBRARIES(adaptive_step_size ${LP_SOLVE} ${BLAS}  ${MKL_LINK}  )
+  TARGET_LINK_LIBRARIES(simple_ode ${LP_SOLVE} ${BLAS} ${MKL_LINK}  )
+  TARGET_LINK_LIBRARIES(simple_sde ${LP_SOLVE} ${BLAS} ${MKL_LINK}  )
+  TARGET_LINK_LIBRARIES(simple_uld ${LP_SOLVE} ${BLAS} ${MKL_LINK}   )
+  TARGET_LINK_LIBRARIES(simple_hmc ${LP_SOLVE} ${BLAS} ${MKL_LINK} )
+  TARGET_LINK_LIBRARIES(exponential_exact_hmc ${LP_SOLVE} ${BLAS} ${MKL_LINK}  )
+  TARGET_LINK_LIBRARIES(gaussian_exact_hmc ${LP_SOLVE} ${BLAS} ${MKL_LINK}  )
   
 
 endif()

--- a/examples/logconcave/README.md
+++ b/examples/logconcave/README.md
@@ -1,4 +1,18 @@
 # Running the Examples
+
+You have to install the latest mkl
+[MKL](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl-download.html)
+For example, it is installed in the directory "/opt/intel/oneapi/mkl/2022.1.0". 
+
+Change the environment variable:
+```bash
+export LD_LIBRARY_PATH=/opt/intel/oneapi/mkl/2022.0.2/lib/intel64
+```
+Change the variable in CMakeLists.txt
+```
+set(MKLROOT /opt/intel/oneapi/mkl/2022.1.0)
+```
+
 Build the example by running the following commands in this directory.
 
 ```bash

--- a/examples/logconcave/README.md
+++ b/examples/logconcave/README.md
@@ -6,11 +6,11 @@ For example, it is installed in the directory "/opt/intel/oneapi/mkl/2022.1.0".
 
 Change the environment variable:
 ```bash
-export LD_LIBRARY_PATH=/opt/intel/oneapi/mkl/2022.0.2/lib/intel64
+export LD_LIBRARY_PATH=/opt/intel/oneapi/mkl/latest/lib/intel64
 ```
 Change the variable in CMakeLists.txt
 ```
-set(MKLROOT /opt/intel/oneapi/mkl/2022.1.0)
+set(MKLROOT /opt/intel/oneapi/mkl/latest)
 ```
 
 Build the example by running the following commands in this directory.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,13 +19,13 @@ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 if (APPLE)
 	set(MKLROOT /opt/intel/oneapi/mkl/latest)
 elseif(UNIX)
-	set(MKLROOT $ENV{HOME}/intel/mkl)
+	set(MKLROOT /opt/intel/oneapi/mkl/latest)
 endif()
 
 
 option(DISABLE_NLP_ORACLES "Disable non-linear oracles (used in collocation)" ON)
 option(BUILTIN_EIGEN "Use eigen from ../external" OFF)
-option(USE_MKL "Use MKL library to build eigen" OFF)
+option(USE_MKL "Use MKL library to build eigen" ON)
 
 if(DISABLE_NLP_ORACLES)
   add_definitions(-DDISABLE_NLP_ORACLES)
@@ -191,6 +191,7 @@ else ()
   add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-lm")
   add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-ldl")
   add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-DBOOST_NO_AUTO_PTR")
+  add_definitions(${CMAKE_CXX_FLAGS} "-DMKL_ILP64")
   #add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-lgslcblas")
   #add_definitions( "-O3 -lgsl -lm -ldl -lgslcblas" )
 


### PR DESCRIPTION
This PR contains 

- instructions to download and configure the latest MKL libraries 
- error fix in the Cmake files. 

It will enable users to build examples using the latest MKL libraries. 
With MKL correctly installed and linked, it will solve these #236 #220 #223 