### PR TITLE
Remove volesti4dingo branch

### DIFF
--- a/R-proj/src/Makevars
+++ b/R-proj/src/Makevars
@@ -2,8 +2,6 @@ PKG_CPPFLAGS= -I../../external/boost -I../../external/LPsolve_src/run_headers -I
 
 PKG_CXXFLAGS= -Wno-deprecated-declarations -lm -ldl -Wno-ignored-attributes -DBOOST_NO_AUTO_PTR -DDISABLE_NLP_ORACLES
 
-CXX_STD = CXX11
-
 PKG_LIBS=-LRproj_externals/lp_solve -llp_solve -L../../external/PackedCSparse/qd -lqd $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 
 $(SHLIB): Rproj_externals/lp_solve/liblp_solve.a ../../external/PackedCSparse/qd/libqd.a

--- a/R-proj/src/Makevars.win
+++ b/R-proj/src/Makevars.win
@@ -1,6 +1,5 @@
 PKG_CPPFLAGS=-I../../external/boost -I../../external/LPsolve_src/run_headers -I../../external/minimum_ellipsoid -I../../include -I../../include/convex_bodies/spectrahedra
 PKG_CXXFLAGS= -Wno-deprecated-declarations -lm -ldl -Wno-ignored-attributes -DBOOST_NO_AUTO_PTR -DDISABLE_NLP_ORACLES
-CXX_STD = CXX11
 
 PKG_LIBS=-LRproj_externals/lp_solve -llp_solve -L../../external/PackedCSparse/qd -lqd $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 

--- a/cran_gen/Makevars
+++ b/cran_gen/Makevars
@@ -1,6 +1,5 @@
 PKG_CPPFLAGS=-Iexternal -Iexternal/lpsolve/headers/run_headers -Iexternal/minimum_ellipsoid -Iinclude -Iinclude/convex_bodies/spectrahedra
 PKG_CXXFLAGS= -DBOOST_NO_AUTO_PTR -DDISABLE_NLP_ORACLES
-CXX_STD = CXX11
 
 PKG_LIBS=-Lexternal/lpsolve/build/lp_solve -llp_solve -Lexternal/PackedCSparse/qd -lqd $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 

--- a/cran_gen/Makevars.win
+++ b/cran_gen/Makevars.win
@@ -1,6 +1,5 @@
 PKG_CPPFLAGS=-Iexternal -Iexternal/lpsolve/headers/run_headers -Iexternal/minimum_ellipsoid -Iinclude -Iinclude/convex_bodies/spectrahedra
 PKG_CXXFLAGS= -lm -ldl -DBOOST_NO_AUTO_PTR -DDISABLE_NLP_ORACLES
-CXX_STD = CXX11
 
 PKG_LIBS=-Lexternal/lpsolve/build/lp_solve -llp_solve -Lexternal/PackedCSparse/qd -lqd $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 

--- a/include/convex_bodies/orderpolytope.h
+++ b/include/convex_bodies/orderpolytope.h
@@ -208,7 +208,32 @@ public:
     std::pair<Point, NT> ComputeInnerBall()
     {
         normalize();
-        return ComputeChebychevBall<NT, Point>(_A, b);
+        std::pair<Point, NT> inner_ball;
+        #ifndef DISABLE_LPSOLVE
+            inner_ball = ComputeChebychevBall<NT, Point>(_A, b); // use lpsolve library
+        #else
+
+            if (inner_ball.second <= NT(0)) {
+
+                NT const tol = 0.00000001;
+                std::tuple<VT, NT, bool> inner_ball = max_inscribed_ball(_A, b, 150, tol);
+
+                // check if the solution is feasible
+                if (is_in(Point(std::get<0>(inner_ball))) == 0 || std::get<1>(inner_ball) < NT(0) ||
+                    std::isnan(std::get<1>(inner_ball)) || std::isinf(std::get<1>(inner_ball)) ||
+                    !std::get<2>(inner_ball) || is_inner_point_nan_inf(std::get<0>(inner_ball)))
+                {
+                    inner_ball.second = -1.0;
+                } else
+                {
+                    inner_ball.first = Point(std::get<0>(inner_ball));
+                    inner_ball.second = std::get<1>(inner_ball);
+                }
+            }
+        #endif
+
+        return inner_ball;
+
     }
 
 

--- a/include/ode_solvers/oracle_functors.hpp
+++ b/include/ode_solvers/oracle_functors.hpp
@@ -243,7 +243,7 @@ struct IsotropicLinearFunctor {
 };
 
 
-struct LinearProgramFunctor {
+struct ExponentialFunctor {
 
   // Sample from linear program c^T x (exponential density)
   template <
@@ -256,8 +256,10 @@ struct LinearProgramFunctor {
     NT m; // Strong convexity constant
     NT kappa; // Condition number
     Point c; // Coefficients of LP objective
+    NT a; // Inverse variance
 
-    parameters(Point c_) : order(2), L(1), m(1), kappa(1), c(c_) {};
+    parameters(Point c_) : order(2), L(1), m(1), kappa(1), c(c_), a(1.0) {};
+    parameters(Point c_, NT a_) : order(2), L(1), m(1), kappa(1), c(c_), a(a_) {};
 
   };
 
@@ -277,7 +279,7 @@ struct LinearProgramFunctor {
     Point operator() (unsigned int const& i, pts const& xs, NT const& t) const {
       if (i == params.order - 1) {
         Point y(params.c);
-        return (-1.0) * y;
+        return (-params.a) * y;
       } else {
         return xs[i + 1]; // returns derivative
       }
@@ -298,7 +300,7 @@ struct LinearProgramFunctor {
 
     // The index i represents the state vector index
     NT operator() (Point const& x) const {
-      return x.dot(params.c);
+      return params.a * x.dot(params.c);
     }
 
   };

--- a/test/logconcave_sampling_test.cpp
+++ b/test/logconcave_sampling_test.cpp
@@ -334,12 +334,12 @@ void benchmark_nuts_hmc(bool truncated) {
     bool automatic_burnin = false;
     std::chrono::time_point<std::chrono::high_resolution_clock> start, stop;
 
-    for (unsigned int dim = dim_min; dim <= dim_max; dim+=10) 
+    for (unsigned int dim = dim_min; dim <= dim_max; dim+=10)
     {
       MT samples(dim, n_samples);
       Point x0(dim);
       NutsHamiltonianMonteCarloWalk::parameters<NT, NegativeGradientFunctor> hmc_params(F, dim);
-      if (truncated) 
+      if (truncated)
       {
         Hpolytope P = generate_cube<Hpolytope>(dim, false);
 
@@ -784,8 +784,8 @@ void benchmark_polytope_linear_program_optimization(
     typedef std::vector<Point> pts;
     typedef boost::mt19937 RNGType;
     typedef BoostRandomNumberGenerator<RNGType, NT> RandomNumberGenerator;
-    typedef LinearProgramFunctor::GradientFunctor<Point> NegativeGradientFunctor;
-    typedef LinearProgramFunctor::FunctionFunctor<Point> NegativeLogprobFunctor;
+    typedef ExponentialFunctor::GradientFunctor<Point> NegativeGradientFunctor;
+    typedef ExponentialFunctor::FunctionFunctor<Point> NegativeLogprobFunctor;
     typedef OptimizationFunctor::GradientFunctor<Point, NegativeLogprobFunctor,
         NegativeGradientFunctor> NegativeGradientOptimizationFunctor;
     typedef OptimizationFunctor::FunctionFunctor<Point, NegativeLogprobFunctor,
@@ -816,7 +816,7 @@ void benchmark_polytope_linear_program_optimization(
     }
 
     // Declare oracles for LP
-    LinearProgramFunctor::parameters<NT, Point> lp_params(coeffs);
+    ExponentialFunctor::parameters<NT, Point> lp_params(coeffs);
 
     NegativeGradientFunctor F_lp(lp_params);
     NegativeLogprobFunctor f_lp(lp_params);
@@ -1116,8 +1116,8 @@ void call_test_exp_sampling() {
     typedef HPolytope<Point> Hpolytope;
     std::string name;
     std::vector<std::tuple<Hpolytope, Point, std::string, bool>> polytopes;
-    
-    
+
+
     if (exists_check("metabolic_full_dim/e_coli_biomass_function.txt") && exists_check("metabolic_full_dim/polytope_e_coli.ine")){
       Point biomass_function_e_coli = load_biomass_function<Point, NT>("metabolic_full_dim/e_coli_biomass_function.txt");
       polytopes.push_back(std::make_tuple(read_polytope<Hpolytope, NT>("metabolic_full_dim/polytope_e_coli.ine"), biomass_function_e_coli, "e_coli", true));


### PR DESCRIPTION
This is a PR that helps in removing the volesti4dingo branch used by dingo python package. 
The main issue is lp_solve which is not used by dingo, hence we use the define flag DISABLE_LPSOLVE. 

That could be changed in the future e.g. by removing lp_solve as a dependency.

This PR should fix https://github.com/GeomScale/volesti/issues/284