### PR TITLE
fix macos/ARM/clang compile errors

### DIFF
--- a/external/PackedCSparse/FloatArray.h
+++ b/external/PackedCSparse/FloatArray.h
@@ -8,7 +8,6 @@
 //(https://github.com/ConstrainedSampler/PolytopeSamplerMatlab/blob/master/code/solver/PackedCSparse/PackedChol.h) by Ioannis Iakovidis
 
 #pragma once
-#include <immintrin.h>
 #include <random>
 #include <type_traits>
 namespace PackedCSparse {

--- a/external/PackedCSparse/FloatArray.h
+++ b/external/PackedCSparse/FloatArray.h
@@ -8,6 +8,9 @@
 //(https://github.com/ConstrainedSampler/PolytopeSamplerMatlab/blob/master/code/solver/PackedCSparse/PackedChol.h) by Ioannis Iakovidis
 
 #pragma once
+#if defined(__x86_64__) || defined(__i386__)
+    #include <immintrin.h>
+#endif
 #include <random>
 #include <type_traits>
 namespace PackedCSparse {

--- a/external/cmake-files/Eigen.cmake
+++ b/external/cmake-files/Eigen.cmake
@@ -1,6 +1,6 @@
 set(EIGEN_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
 function(GetEigen)
-  find_path(EIGEN_DIR NAMES Eigen PATHS ${EIGEN_CMAKE_DIR}/../_deps/eigen-src)
+  find_path(EIGEN_DIR NAMES signature_of_eigen3_matrix_library PATHS ${EIGEN_CMAKE_DIR}/../_deps/eigen-src PATH_SUFFIXES eigen3 eigen)
 
   if (NOT EIGEN_DIR) 
     include(FetchContent)

--- a/external/cmake-files/LPSolve.cmake
+++ b/external/cmake-files/LPSolve.cmake
@@ -1,6 +1,8 @@
 set(LP_SOLVE_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
 function(GetLPSolve)
+if(NOT APPLE)
   find_path(LP_SOLVE_DIR NAMES lpsolve.h PATHS ${LP_SOLVE_CMAKE_DIR}/../_deps/lpsolve-src)
+endif(NOT APPLE)
 
   if (NOT LP_SOLVE_DIR)
       include(FetchContent)

--- a/include/ode_solvers/implicit_midpoint.hpp
+++ b/include/ode_solvers/implicit_midpoint.hpp
@@ -104,11 +104,11 @@ struct ImplicitMidpointODESolver {
     num_runs++;
     pts partialDerivatives;
 #ifdef TIME_KEEPING
-    start = std::chrono::system_clock::now();
+    start = std::chrono::high_resolution_clock::now();
 #endif
     partialDerivatives = ham.DU(xs);
 #ifdef TIME_KEEPING
-    end = std::chrono::system_clock::now();
+    end = std::chrono::high_resolution_clock::now();
     DU_duration += end - start;
 #endif
     xs = xs + partialDerivatives * (eta / 2);
@@ -119,12 +119,12 @@ struct ImplicitMidpointODESolver {
       pts xs_old = xs;
       pts xmid = (xs_prev + xs) / 2.0;
 #ifdef TIME_KEEPING
-      start = std::chrono::system_clock::now();
+      start = std::chrono::high_resolution_clock::now();
 #endif
       partialDerivatives = ham.approxDK(xmid, nu);
 
 #ifdef TIME_KEEPING
-      end = std::chrono::system_clock::now();
+      end = std::chrono::high_resolution_clock::now();
       approxDK_duration += end - start;
 #endif
       xs = xs_prev + partialDerivatives * (eta);
@@ -144,11 +144,11 @@ struct ImplicitMidpointODESolver {
       }
     }
 #ifdef TIME_KEEPING
-    start = std::chrono::system_clock::now();
+    start = std::chrono::high_resolution_clock::now();
 #endif
     partialDerivatives = ham.DU(xs);
 #ifdef TIME_KEEPING
-    end = std::chrono::system_clock::now();
+    end = std::chrono::high_resolution_clock::now();
     DU_duration += end - start;
 #endif
     xs = xs + partialDerivatives * (eta / 2);

--- a/include/preprocess/crhmc/crhmc_problem.h
+++ b/include/preprocess/crhmc/crhmc_problem.h
@@ -330,23 +330,23 @@ public:
   void simplify() {
 #ifdef TIME_KEEPING
     std::chrono::time_point<std::chrono::high_resolution_clock> start, end;
-    start = std::chrono::system_clock::now();
+    start = std::chrono::high_resolution_clock::now();
 #endif
     rescale();
 #ifdef TIME_KEEPING
-    end = std::chrono::system_clock::now();
+    end = std::chrono::high_resolution_clock::now();
     rescale_duration += end - start;
-    start = std::chrono::system_clock::now();
+    start = std::chrono::high_resolution_clock::now();
 #endif
     splitDenseCols(options.maxNZ);
 #ifdef TIME_KEEPING
-    end = std::chrono::system_clock::now();
+    end = std::chrono::high_resolution_clock::now();
     sparsify_duration += end - start;
-    start = std::chrono::system_clock::now();
+    start = std::chrono::high_resolution_clock::now();
 #endif
     reorder();
 #ifdef TIME_KEEPING
-    end = std::chrono::system_clock::now();
+    end = std::chrono::high_resolution_clock::now();
     reordering_duration += end - start;
 #endif
     int changed = 1;
@@ -354,32 +354,32 @@ public:
       while (changed) {
         changed = 0;
 #ifdef TIME_KEEPING
-        start = std::chrono::system_clock::now();
+        start = std::chrono::high_resolution_clock::now();
 #endif
         changed += remove_dependent_rows();
 #ifdef TIME_KEEPING
-        end = std::chrono::system_clock::now();
+        end = std::chrono::high_resolution_clock::now();
         rm_rows_duration += end - start;
-        start = std::chrono::system_clock::now();
+        start = std::chrono::high_resolution_clock::now();
 #endif
         changed += remove_fixed_variables();
 #ifdef TIME_KEEPING
-        end = std::chrono::system_clock::now();
+        end = std::chrono::high_resolution_clock::now();
         rm_fixed_vars_duration += end - start;
-        start = std::chrono::system_clock::now();
+        start = std::chrono::high_resolution_clock::now();
 #endif
         reorder();
 #ifdef TIME_KEEPING
-        end = std::chrono::system_clock::now();
+        end = std::chrono::high_resolution_clock::now();
         reordering_duration += end - start;
 #endif
       }
 #ifdef TIME_KEEPING
-      start = std::chrono::system_clock::now();
+      start = std::chrono::high_resolution_clock::now();
 #endif
       changed += extract_collapsed_variables();
 #ifdef TIME_KEEPING
-      end = std::chrono::system_clock::now();
+      end = std::chrono::high_resolution_clock::now();
       ex_collapsed_vars_duration += end - start;
 #endif
     }
@@ -546,7 +546,7 @@ public:
     simplify();
 #ifdef TIME_KEEPING
     std::chrono::time_point<std::chrono::high_resolution_clock> start, end;
-    start = std::chrono::system_clock::now();
+    start = std::chrono::high_resolution_clock::now();
 #endif
     if (isempty_center) {
       std::tie(center, std::ignore, std::ignore) =
@@ -555,7 +555,7 @@ public:
     }
     shift_barrier(center);
 #ifdef TIME_KEEPING
-    end = std::chrono::system_clock::now();
+    end = std::chrono::high_resolution_clock::now();
     shift_barrier_duration += end - start;
 #endif
     reorder();
@@ -564,7 +564,7 @@ public:
     //  Recenter again and make sure it is feasible
     VT hess;
 #ifdef TIME_KEEPING
-    start = std::chrono::system_clock::now();
+    start = std::chrono::high_resolution_clock::now();
 #endif
     std::tie(center, std::ignore, std::ignore, w_center) =
         lewis_center<Crhmc_problem, SpMat, Opts, MT, VT, NT>(Asp, b, *this, options, center);
@@ -578,7 +578,7 @@ public:
     solver.solve((Tx *)input.data(), (Tx *)out.data());
     center = center + (Asp.transpose() * out).cwiseProduct(Hinv);
 #ifdef TIME_KEEPING
-    end = std::chrono::system_clock::now();
+    end = std::chrono::high_resolution_clock::now();
     lewis_center_duration += end - start;
 #endif
     if ((center.array() > barrier.ub.array()).any() ||

--- a/include/random_walks/crhmc/crhmc_walk.hpp
+++ b/include/random_walks/crhmc/crhmc_walk.hpp
@@ -182,7 +182,7 @@ struct CRHMCWalk {
       v_tilde = solver->get_state(1);
       if (metropolis_filter) {
 #ifdef TIME_KEEPING
-        start = std::chrono::system_clock::now();
+        start = std::chrono::high_resolution_clock::now();
 #endif
         // Calculate initial Hamiltonian
         H = solver->ham.hamiltonian(x, v);
@@ -191,7 +191,7 @@ struct CRHMCWalk {
         H_tilde = solver->ham.hamiltonian(x_tilde, -v_tilde);
 
 #ifdef TIME_KEEPING
-        end = std::chrono::system_clock::now();
+        end = std::chrono::high_resolution_clock::now();
         H_duration += end - start;
 #endif
         VT feasible = solver->ham.feasible(x_tilde,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -176,7 +176,7 @@ add_definitions(${CMAKE_CXX_FLAGS} "-g")  # enable debuger
 #add_definitions(${CMAKE_CXX_FLAGS} "-Wall")
 
 add_definitions(${CMAKE_CXX_FLAGS} "-O3")  # optimization of the compiler
-add_definitions(${CMAKE_CXX_FLAGS} "-std=c++17") #enable the c++17 support needed by autodiff
+set(CMAKE_CXX_STANDARD 17)  #enable the c++17 support needed by autodiff
 #add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-lgsl")
 add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-lm")
 add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-ldl")

--- a/test/benchmarks_crhmc.cpp
+++ b/test/benchmarks_crhmc.cpp
@@ -51,9 +51,9 @@ double benchmark(std::string fileName) {
   std::chrono::time_point<std::chrono::high_resolution_clock> start, end;
   std::cout << "CRHMC polytope preparation for " << fileName << std::endl;
 
-  start = std::chrono::system_clock::now();
+  start = std::chrono::high_resolution_clock::now();
   CrhmcProblem P = CrhmcProblem(input);
-  end = std::chrono::system_clock::now();
+  end = std::chrono::high_resolution_clock::now();
 
   std::cout << "Preparation completed in time, ";
   std::chrono::duration<double> elapsed_seconds = end - start;
@@ -80,9 +80,9 @@ int main() {
   std::cout << "CRHMC polytope preparation 100000 dimensional Cube "
             << std::endl;
 
-  start = std::chrono::system_clock::now();
+  start = std::chrono::high_resolution_clock::now();
   CrhmcProblem P = CrhmcProblem(input);
-  end = std::chrono::system_clock::now();
+  end = std::chrono::high_resolution_clock::now();
 
   std::cout << "Preparation completed in time, ";
   std::chrono::duration<double> elapsed_seconds = end - start;


### PR DESCRIPTION
This PR fixes compile errors on ARM macos with clang, see #295 

NOTE: this PR removes `#include <immintrin.h>` in file `external/PackedCSparse/FloatArray.h`