### PR TITLE
Sparse optimizations for UniformABW sampling

### DIFF
--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -570,9 +570,9 @@ public:
 
     template <typename update_parameters, typename set_type, typename AA_type>
     std::pair<NT, int> line_positive_intersect(Point const& r,
-                                                     Point const& v,
                                                      VT& Ar,
                                                      VT& Av,
+                                                     NT const& lambda_prev,
                                                      VT& distances_vec,
                                                      set_type& distances_set,
                                                      AA_type const& AA,
@@ -593,7 +593,8 @@ public:
             *(Av_data + it.row()) += (-2.0 * inner_prev) * it.value();
             *(Ar_data + it.row()) -= (-2.0 * inner_prev * params.moved_dist) * it.value();
 
-            distances_set.erase(std::make_pair(*(dvec_data + it.row()), it.row()));
+            if(*(dvec_data + it.row()) > params.moved_dist - lambda_prev)
+                distances_set.erase(std::make_pair(*(dvec_data + it.row()), it.row()));
             
             *(dvec_data + it.row()) = (*(b_data + it.row()) - *(Ar_data + it.row())) / *(Av_data + it.row());
 

--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -525,7 +525,7 @@ public:
                                                      VT& Av,
                                                      NT const& lambda_prev,
                                                      DenseMT const& AA,
-                                                     update_parameters& params) const
+                                                     update_parameters& params) const //
     {
 
         NT min_plus  = std::numeric_limits<NT>::max();
@@ -954,9 +954,15 @@ public:
 
     template <typename update_parameters>
     void compute_reflection(Point &v, const Point &, update_parameters const& params) const {
-
-            Point a((-2.0 * params.inner_vi_ak) * A.row(params.facet_prev));
-            v += a;
+            if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) { // is faster only if MT is RowMajor
+                NT* v_data = v.pointerToData();
+                for(Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(A, params.facet_prev); it; ++it) {
+                    *(v_data + it.col()) += (-2.0 * params.inner_vi_ak) * it.value();
+                }
+            } else {
+                Point a((-2.0 * params.inner_vi_ak) * A.row(params.facet_prev));
+                v += a;
+            }
     }
 
     template <typename update_parameters>

--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -525,7 +525,7 @@ public:
                                                      VT& Av,
                                                      NT const& lambda_prev,
                                                      DenseMT const& AA,
-                                                     update_parameters& params) const //
+                                                     update_parameters& params) const//
     {
 
         NT min_plus  = std::numeric_limits<NT>::max();
@@ -918,7 +918,7 @@ public:
         normalized = true;
     }
 
-    void compute_reflection(Point& v, Point const&, int const& facet) const
+    void compute_reflection(Point& v, Point& p, int const& facet) const
     {
         v += -2 * v.dot(A.row(facet)) * A.row(facet);
     }
@@ -953,11 +953,13 @@ public:
     }
 
     template <typename update_parameters>
-    void compute_reflection(Point &v, const Point &, update_parameters const& params) const {
-            if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) { // is faster only if MT is RowMajor
+    void compute_reflection(Point &v, Point &p, update_parameters const& params) const {
+            if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) { // is faster only if MT is in RowMajor format
                 NT* v_data = v.pointerToData();
+                NT* p_data = p.pointerToData();
                 for(Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(A, params.facet_prev); it; ++it) {
                     *(v_data + it.col()) += (-2.0 * params.inner_vi_ak) * it.value();
+                    *(p_data + it.col()) -= (-2.0 * params.inner_vi_ak * params.moved_dist) * it.value();
                 }
             } else {
                 Point a((-2.0 * params.inner_vi_ak) * A.row(params.facet_prev));

--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -974,7 +974,7 @@ public:
         normalized = true;
     }
 
-    void compute_reflection(Point& v, Point& p, int const& facet) const
+    void compute_reflection(Point& v, Point const&, int const& facet) const
     {
         v += -2 * v.dot(A.row(facet)) * A.row(facet);
     }
@@ -1009,7 +1009,13 @@ public:
     }
 
     template <typename update_parameters>
-    void compute_reflection(Point &v, Point &p, update_parameters const& params) const {
+    void compute_reflection(Point &v, Point const&, update_parameters const& params) const {
+            Point a((-2.0 * params.inner_vi_ak) * A.row(params.facet_prev));
+            v += a;
+    }
+
+    template <typename update_parameters>
+    void compute_reflection_abw(Point &v, Point &p, update_parameters const& params) const {
             if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) { // MT must be in RowMajor format
                 NT* v_data = v.pointerToData();
                 NT* p_data = p.pointerToData();

--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -1015,17 +1015,13 @@ public:
     }
 
     template <typename update_parameters>
-    void compute_reflection_abw(Point &v, Point &p, update_parameters const& params) const {
-            if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) { // MT must be in RowMajor format
-                NT* v_data = v.pointerToData();
-                NT* p_data = p.pointerToData();
-                for(Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(A, params.facet_prev); it; ++it) {
-                    *(v_data + it.col()) += (-2.0 * params.inner_vi_ak) * it.value();
-                    *(p_data + it.col()) -= (-2.0 * params.inner_vi_ak * params.moved_dist) * it.value();
-                }
-            } else {
-                Point a((-2.0 * params.inner_vi_ak) * A.row(params.facet_prev));
-                v += a;
+    auto compute_reflection(Point &v, Point &p, update_parameters const& params) const
+         -> std::enable_if_t<std::is_same_v<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>> && !std::is_same_v<update_parameters, int>, void> { // MT must be in RowMajor format
+            NT* v_data = v.pointerToData();
+            NT* p_data = p.pointerToData();
+            for(Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(A, params.facet_prev); it; ++it) {
+                *(v_data + it.col()) += (-2.0 * params.inner_vi_ak) * it.value();
+                *(p_data + it.col()) -= (-2.0 * params.inner_vi_ak * params.moved_dist) * it.value();
             }
     }
 

--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -573,61 +573,23 @@ public:
                                                      VT& Ar,
                                                      VT& Av,
                                                      NT const& lambda_prev,
-                                                     VT& distances_vec,
                                                      set_type& distances_set,
                                                      AA_type const& AA,
                                                      update_parameters& params) const
     {
         NT inner_prev = params.inner_vi_ak;
-
-        // real Ar            = Ar + params.moved_dist * Av
-        // real r             = r + params.moved_dist * v
-        // real distances_vec = distances_vec - params.moved_dist
         
         NT* Av_data = Av.data();
-        //NT* Ar_data = Ar.data();
-        //NT* dvec_data = distances_vec.data();
         const NT* b_data = b.data();
 
         for (Eigen::SparseMatrix<double>::InnerIterator it(AA, params.facet_prev); it; ++it) {
 
-            // NT old_Av = *(Av_data + it.row());
-
             *(Av_data + it.row()) += (-2.0 * inner_prev) * it.value();
-            //*(Ar_data + it.row()) -= (-2.0 * inner_prev * params.moved_dist) * it.value();
-
-            //if(*(dvec_data + it.row()) > params.moved_dist - lambda_prev)
-            //    distances_set.erase(std::make_pair(*(dvec_data + it.row()), it.row()));
-            
-            // *(dvec_data + it.row()) = (*(b_data + it.row()) - *(Ar_data + it.row())) / *(Av_data + it.row());
-            // *(dvec_data + it.row()) = (*(dvec_data + it.row()) - params.moved_dist) * old_Av / *(Av_data + it.row()) + params.moved_dist;
-            // *(dvec_data + it.row()) += (*(dvec_data + it.row()) - params.moved_dist) * 2.0 * inner_prev * it.value() / *(Av_data + it.row());
-
             NT val = distances_set.get_val(it.row());
             val += (val - params.moved_dist) * 2.0 * inner_prev * it.value() / *(Av_data + it.row());
             distances_set.change_val(it.row(), val, params.moved_dist);
-
-            //if(*(dvec_data + it.row()) > params.moved_dist)
-            //    distances_set.insert(std::make_pair(*(dvec_data + it.row()), it.row()));
         }
-        /*
-        std::cout << "got here post!!" << std::endl;
-        std::cout << std::endl;
-        std::cout << distances_set.heap_size << std::endl;
-        std::cout << params.moved_dist << std::endl;
-        std::cout << lambda_prev << std::endl;
-        for(int i = 0; i < num_of_hyperplanes(); ++i) {
-            std::cout << distances_set.heap[i].first << ' ';
-        }
-        std::cout << std::endl << std::endl;*/
-
-        /*auto it = distances_set.upper_bound(std::make_pair(-9999999, 0));
-
-        if(it == distances_set.end()) {
-            std::cout << "something went wrong when trying to get lowest positive value" << std::endl;
-            throw "all values from the set were negative";
-        }
-        */
+        
         std::pair<NT, int> ans = distances_set.get_min();
         ans.first -= params.moved_dist;
 

--- a/include/preprocess/rounding_util_functions.hpp
+++ b/include/preprocess/rounding_util_functions.hpp
@@ -57,7 +57,7 @@ initialize_chol(MT const& mat)
     if constexpr (std::is_same<MT, DenseMT>::value)
     {
         return std::make_unique<Eigen::LLT<MT>>();
-    } else if constexpr (std::is_same<MT, SparseMT>::value)  
+    } else if constexpr (std::is_base_of<Eigen::SparseMatrixBase<MT>, MT >::value)  
     {
         auto llt = std::make_unique<Eigen::SimplicialLLT<MT>>();
         llt->analyzePattern(mat);
@@ -78,7 +78,7 @@ initialize_chol(MT const& A_trans, MT const& A)
     if constexpr (std::is_same<MT, DenseMT>::value)
     {
         return std::make_unique<Eigen::LLT<MT>>();
-    } else if constexpr (std::is_same<MT, SparseMT>::value)  
+    } else if constexpr (std::is_base_of<Eigen::SparseMatrixBase<MT>, MT >::value)  
     {
         MT mat = A_trans * A;
         return initialize_chol<NT>(mat);
@@ -99,7 +99,7 @@ inline static VT solve_vec(std::unique_ptr<Eigen_lltMT> const& llt,
     {
         llt->compute(H);
         return llt->solve(b);
-    } else if constexpr (std::is_same<MT, SparseMT>::value)  
+    } else if constexpr (std::is_base_of<Eigen::SparseMatrixBase<MT>, MT >::value)  
     {
         llt->factorize(H);
         return llt->solve(b);
@@ -122,7 +122,7 @@ solve_mat(std::unique_ptr<Eigen_lltMT> const& llt,
         llt->compute(H);
         logdetE = llt->matrixL().toDenseMatrix().diagonal().array().log().sum();
         return llt->solve(mat);
-    } else if constexpr (std::is_same<MT, SparseMT>::value)  
+    } else if constexpr (std::is_base_of<Eigen::SparseMatrixBase<MT>, MT >::value)  
     {
         llt->factorize(H);
         logdetE = llt->matrixL().nestedExpression().diagonal().array().log().sum();
@@ -143,7 +143,7 @@ inline static void update_Atrans_Diag_A(MT &H, MT const& A_trans,
     if constexpr (std::is_same<MT, DenseMT>::value)
     {
         H.noalias() = A_trans * D * A;
-    } else if constexpr (std::is_same<MT, SparseMT>::value)  
+    } else if constexpr (std::is_base_of<Eigen::SparseMatrixBase<MT>, MT >::value)  
     {
         H = A_trans * D * A;
     } else 
@@ -161,7 +161,7 @@ inline static void update_Diag_A(MT &H, diag_MT const& D, MT const& A)
     if constexpr (std::is_same<MT, DenseMT>::value)
     {
         H.noalias() = D * A;
-    } else if constexpr (std::is_same<MT, SparseMT>::value)  
+    } else if constexpr (std::is_base_of<Eigen::SparseMatrixBase<MT>, MT >::value)  
     {
         H = D * A;
     } else 
@@ -179,7 +179,7 @@ inline static void update_A_Diag(MT &H, MT const& A, diag_MT const& D)
     if constexpr (std::is_same<MT, DenseMT>::value)
     {
         H.noalias() = A * D;
-    } else if constexpr (std::is_same<MT, SparseMT>::value)  
+    } else if constexpr (std::is_base_of<Eigen::SparseMatrixBase<MT>, MT >::value)  
     {
         H = A * D;
     } else 
@@ -198,7 +198,7 @@ get_mat_prod_op(MT const& E)
     if constexpr (std::is_same<MT, DenseMT>::value)
     {
         return std::make_unique<Spectra::DenseSymMatProd<NT>>(E);
-    } else if constexpr (std::is_same<MT, SparseMT>::value)  
+    } else if constexpr (std::is_base_of<Eigen::SparseMatrixBase<MT>, MT >::value)  
     {
         return std::make_unique<Spectra::SparseSymMatProd<NT>>(E);
     } else 
@@ -249,7 +249,7 @@ init_Bmat(MT &B, int const n, MT const& A_trans, MT const& A)
     if constexpr (std::is_same<MT, DenseMT>::value)
     {
         B.resize(n+1, n+1);
-    } else if constexpr (std::is_same<MT, SparseMT>::value)  
+    } else if constexpr (std::is_base_of<Eigen::SparseMatrixBase<MT>, MT >::value)  
     {
         // Initialize the structure of matrix B
         typedef Eigen::Triplet<NT> triplet;
@@ -299,7 +299,7 @@ update_Bmat(MT &B, VT const& AtDe, VT const& d,
         B.block(n, 0, 1, n).noalias() = AtDe.transpose();
         B(n, n) = d.sum();
         B.noalias() += 1e-14 * MT::Identity(n + 1, n + 1);
-    } else if constexpr (std::is_same<MT, SparseMT>::value)  
+    } else if constexpr (std::is_base_of<Eigen::SparseMatrixBase<MT>, MT >::value)  
     {
         MT AtD_A = AtD * A;
         int k = 0;

--- a/include/random_walks/gaussian_accelerated_billiard_walk.hpp
+++ b/include/random_walks/gaussian_accelerated_billiard_walk.hpp
@@ -73,7 +73,7 @@ struct GaussianAcceleratedBilliardWalk
 
         void computeLcov(const E_type E)
         {
-            if constexpr (std::is_same<E_type, Eigen::SparseMatrix<NT> >::value) {
+            if constexpr (std::is_base_of<Eigen::SparseMatrixBase<E_type>, E_type >::value) {
                 Eigen::SimplicialLLT<E_type> lltofE;
                 lltofE.compute(E);
                 if (lltofE.info() != Eigen::Success) {

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -16,10 +16,13 @@
 #include <set>
 #include <vector>
 
-const double eps = 0.000000001;
+const double eps = 0.0000000001;
 
+// data structure which maintains the values of (b - Ar)/Av, and can extract the minimum positive value and the facet associated with it
+// vec[i].first contains the value of (b(i) - Ar(i))/Av(i) + moved_dist, where moved_dist is the total distance that the point has travelled so far
+// The heap will only contain the values from vec which are greater than moved_dist (so that they are positive)
 template<typename NT>
-class Heap {
+class BoundaryOracleHeap {
 public:
     int n, heap_size;
     std::vector<std::pair<NT, int>> heap;
@@ -53,6 +56,28 @@ private:
         return index;
     }
 
+    // takes the index of a facet, and (in case it is in the heap) removes it from the heap.
+    void remove (int index) {
+        index = vec[index].second;
+        if(index == -1) {
+            return;
+        }
+        std::swap(heap[heap_size - 1], heap[index]);
+        std::swap(vec[heap[heap_size - 1].second].second, vec[heap[index].second].second);
+        vec[heap[heap_size - 1].second].second = -1;
+        heap_size -= 1;
+        index = siftDown(index);
+        siftUp(index);
+    }
+
+    // inserts a new value into the heap, with its associated facet
+    void insert (const std::pair<NT, int> val) {
+        vec[val.second].second = heap_size;
+        vec[val.second].first = val.first;
+        heap[heap_size++] = val;
+        siftUp(heap_size - 1);
+    }
+
 public:
     Heap() {}
 
@@ -61,6 +86,8 @@ public:
         vec.resize(n);
     }
 
+    // rebuilds the heap with the existing values from vec
+    // O(n)
     void rebuild (const NT &moved_dist) {
         heap_size = 0;
         for(int i = 0; i < n; ++i) {
@@ -75,35 +102,21 @@ public:
         }
     }
 
+    // returns (b(i) - Ar(i))/Av(i) + moved_dist
+    // O(1)
     NT get_val (const int &index) {
         return vec[index].first;
     }
 
+    // returns the nearest facet
+    // O(1)
     std::pair<NT, int> get_min () {
         return heap[0];
     }
 
-    void remove (int index) { // takes the index from the vec
-        index = vec[index].second;
-        if(index == -1) {
-            return;
-        }
-        std::swap(heap[heap_size - 1], heap[index]);
-        std::swap(vec[heap[heap_size - 1].second].second, vec[heap[index].second].second);
-        vec[heap[heap_size - 1].second].second = -1;
-        heap_size -= 1;
-        index = siftDown(index);
-        siftUp(index);
-    }
-
-    void insert (const std::pair<NT, int> val) {
-        vec[val.second].second = heap_size;
-        vec[val.second].first = val.first;
-        heap[heap_size++] = val;
-        siftUp(heap_size - 1);
-    }
-
-    void change_val(const int& index, const NT& new_val, const NT& moved_dist) { // takes the index from the vec
+    // changes the stored value for a given facet, and updates the heap accordingly
+    // O(logn)
+    void change_val(const int& index, const NT& new_val, const NT& moved_dist) {
         if(new_val < moved_dist - eps) {
             vec[index].first = new_val;
             remove(index);
@@ -222,6 +235,8 @@ struct AcceleratedBilliardWalk
             NT T;
             const NT dl = 0.995;
             int it;
+            typename Point::Coeff b = P.get_vec();
+            NT* b_data = b.data();
 
             for (auto j=0u; j<walk_length; ++j)
             {
@@ -241,13 +256,12 @@ struct AcceleratedBilliardWalk
                 _lambda_prev = dl * pbpair.first;
                 if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) {
                     _update_parameters.moved_dist = _lambda_prev;
-                    typename Point::Coeff b = P.get_vec();
-                    NT* b_data = b.data();
                     NT* Ar_data = _lambdas.data();
                     NT* Av_data = _Av.data();
                     for(int i = 0; i < P.num_of_hyperplanes(); ++i) {
                         _distances_set.vec[i].first = ( *(b_data + i) - (*(Ar_data + i)) ) / (*(Av_data + i));
                     }
+                    // rebuild the heap with the new values of (b - Ar) / Av
                     _distances_set.rebuild(_update_parameters.moved_dist);
                 } else {
                     _p += (_lambda_prev * _v);
@@ -451,7 +465,7 @@ struct AcceleratedBilliardWalk
         update_parameters _update_parameters;
         typename Point::Coeff _lambdas;
         typename Point::Coeff _Av;
-        Heap<NT> _distances_set;
+        BoundaryOracleHeap<NT> _distances_set;
     };
 
 };

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -16,7 +16,7 @@
 #include <set>
 #include <vector>
 
-const double eps = 0.0000000001;
+const double eps = 1e-10;
 
 // data structure which maintains the values of (b - Ar)/Av, and can extract the minimum positive value and the facet associated with it
 // vec[i].first contains the value of (b(i) - Ar(i))/Av(i) + moved_dist, where moved_dist is the total distance that the point has travelled so far

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -61,7 +61,7 @@ struct AcceleratedBilliardWalk
     {
         typedef typename Polytope::PointType Point;
         typedef typename Polytope::MT MT;
-        typedef typename Polytope::DenseMT DenseMT;
+        typedef typename Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> DenseMT;
         typedef typename Point::FT NT;
         using AA_type = std::conditional_t< std::is_same_v<MT, typename Eigen::SparseMatrix<NT, Eigen::RowMajor>>, typename Eigen::SparseMatrix<NT>, DenseMT >; 
         // AA is sparse colMajor if MT is sparse rowMajor, and Dense otherwise
@@ -152,7 +152,7 @@ struct AcceleratedBilliardWalk
                     _p += (_lambda_prev * _v);
                 }
                 T -= _lambda_prev;
-                P.compute_reflection_abw(_v, _p, _update_parameters);
+                P.compute_reflection(_v, _p, _update_parameters);
                 it++;
 
                 while (it < _rho)
@@ -177,7 +177,7 @@ struct AcceleratedBilliardWalk
                         _p += (_lambda_prev * _v);
                     }
                     T -= _lambda_prev;
-                    P.compute_reflection_abw(_v, _p, _update_parameters);
+                    P.compute_reflection(_v, _p, _update_parameters);
                     it++;
                 }
                 _p += _update_parameters.moved_dist * _v;
@@ -298,7 +298,7 @@ struct AcceleratedBilliardWalk
             _lambda_prev = dl * pbpair.first;
             _p += (_lambda_prev * _v);
             T -= _lambda_prev;
-            P.compute_reflection_abw(_v, _p, _update_parameters);
+            P.compute_reflection(_v, _p, _update_parameters);
 
             while (it <= _rho)
             {
@@ -316,7 +316,7 @@ struct AcceleratedBilliardWalk
                 _lambda_prev = dl * pbpair.first;
                 _p += (_lambda_prev * _v);
                 T -= _lambda_prev;
-                P.compute_reflection_abw(_v, _p, _update_parameters);
+                P.compute_reflection(_v, _p, _update_parameters);
                 it++;
             }
         }

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -235,8 +235,10 @@ struct AcceleratedBilliardWalk
             NT T;
             const NT dl = 0.995;
             int it;
-            typename Point::Coeff b = P.get_vec();
-            NT* b_data = b.data();
+            if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) {
+                typename Point::Coeff b = P.get_vec();
+                NT* b_data = b.data();
+            }
 
             for (auto j=0u; j<walk_length; ++j)
             {

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -235,9 +235,11 @@ struct AcceleratedBilliardWalk
             NT T;
             const NT dl = 0.995;
             int it;
+            typename Point::Coeff b;
+            NT* b_data;
             if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) {
-                typename Point::Coeff b = P.get_vec();
-                NT* b_data = b.data();
+                b = P.get_vec();
+                b_data = b.data();
             }
 
             for (auto j=0u; j<walk_length; ++j)

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -159,7 +159,7 @@ struct AcceleratedBilliardWalk
                 {   
                     std::pair<NT, int> pbpair;
                     if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) {
-                        pbpair = P.line_positive_intersect(_p, _v, _lambdas, _Av, _distances_vec,
+                        pbpair = P.line_positive_intersect(_p, _lambdas, _Av, _lambda_prev, _distances_vec,
                                                            _distances_set, _AA, _update_parameters);
                     } else {
                         pbpair = P.line_positive_intersect(_p, _v, _lambdas, _Av, _lambda_prev,

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -79,9 +79,9 @@ private:
     }
 
 public:
-    Heap() {}
+    BoundaryOracleHeap() {}
 
-    Heap(int n) : n(n), heap_size(0) {
+    BoundaryOracleHeap(int n) : n(n), heap_size(0) {
         heap.resize(n);
         vec.resize(n);
     }
@@ -398,7 +398,7 @@ struct AcceleratedBilliardWalk
             _Av.setZero(P.num_of_hyperplanes());
             _p = p;
             _v = GetDirection<Point>::apply(n, rng);
-            _distances_set = Heap<NT>(P.num_of_hyperplanes());
+            _distances_set = BoundaryOracleHeap<NT>(P.num_of_hyperplanes());
 
             NT T = -std::log(rng.sample_urdist()) * _L;
             Point p0 = _p;

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -16,6 +16,8 @@
 #include <set>
 #include <vector>
 
+const double eps = 0.000000001;
+
 template<typename NT>
 class Heap {
 public:
@@ -24,29 +26,31 @@ public:
     std::vector<std::pair<NT, int>> vec;
 
 private:
-    void siftDown(int index) {
+    int siftDown(int index) {
         while((index << 1) + 1 < heap_size) {
             int child = (index << 1) + 1;
-            if(child + 1 < heap_size && heap[child + 1].first < heap[child].first) {
+            if(child + 1 < heap_size && heap[child + 1].first < heap[child].first - eps) {
                 child += 1;
             }
-            if(heap[child].first < heap[index].first)
+            if(heap[child].first < heap[index].first - eps)
             {
                 std::swap(heap[child], heap[index]);
                 std::swap(vec[heap[child].second].second, vec[heap[index].second].second);
                 index = child;
             } else {
-                return;
+                return index;
             }
         }
+        return index;
     }
 
-    void siftUp(int index) {
-        while(index > 0 && heap[(index - 1) >> 1].first > heap[index].first) {
+    int siftUp(int index) {
+        while(index > 0 && heap[(index - 1) >> 1].first - eps > heap[index].first) {
             std::swap(heap[(index - 1) >> 1], heap[index]);
             std::swap(vec[heap[(index - 1) >> 1].second].second, vec[heap[index].second].second);
             index = (index - 1) >> 1;
         }
+        return index;
     }
 
 public:
@@ -79,7 +83,7 @@ public:
         return heap[0];
     }
 
-    void remove (const int index) { // takes the index from the heap
+    void remove (int index) { // takes the index from the heap
         if(index == -1) {
             return;
         }
@@ -87,7 +91,8 @@ public:
         std::swap(vec[heap[heap_size - 1].second].second, vec[heap[index].second].second);
         vec[heap[heap_size - 1].second].second = -1;
         heap_size -= 1;
-        siftDown(index);
+        index = siftDown(index);
+        siftUp(index);
     }
 
     void insert (const std::pair<NT, int> val) {

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -233,19 +233,12 @@ struct AcceleratedBilliardWalk
                 _lambda_prev = dl * pbpair.first;
                 if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) {
                     _update_parameters.moved_dist = _lambda_prev;
-                    //_distances_set.clear();
-                    _distances_vec.setZero(P.num_of_hyperplanes());
                     typename Point::Coeff b = P.get_vec();
                     NT* b_data = b.data();
-                    //NT* dvec_data = _distances_vec.data();
                     NT* Ar_data = _lambdas.data();
                     NT* Av_data = _Av.data();
                     for(int i = 0; i < P.num_of_hyperplanes(); ++i) {
                         _distances_set.vec[i].first = ( *(b_data + i) - (*(Ar_data + i)) ) / (*(Av_data + i));
-                        //std::cout << _distances_set.vec[i].first << ' ';
-                        //*(dvec_data + i) = ( *(b_data + i) - (*(Ar_data + i)) ) / (*(Av_data + i));
-                        //if(*(dvec_data + i) > _update_parameters.moved_dist)
-                        //    _distances_set.insert(std::make_pair(*(dvec_data + i), i));
                     }
                     _distances_set.rebuild(_update_parameters.moved_dist);
                 } else {
@@ -259,7 +252,7 @@ struct AcceleratedBilliardWalk
                 {   
                     std::pair<NT, int> pbpair;
                     if constexpr (std::is_same<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>::value) {
-                        pbpair = P.line_positive_intersect(_p, _lambdas, _Av, _lambda_prev, _distances_vec,
+                        pbpair = P.line_positive_intersect(_p, _lambdas, _Av, _lambda_prev,
                                                            _distances_set, _AA, _update_parameters);
                     } else {
                         pbpair = P.line_positive_intersect(_p, _v, _lambdas, _Av, _lambda_prev,
@@ -450,9 +443,7 @@ struct AcceleratedBilliardWalk
         update_parameters _update_parameters;
         typename Point::Coeff _lambdas;
         typename Point::Coeff _Av;
-        typename Point::Coeff _distances_vec;
         Heap<NT> _distances_set;
-        //std::set<std::pair<NT, int>> _distances_set;
     };
 
 };

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -136,16 +136,16 @@ struct AcceleratedBilliardWalk
                 {
                     std::pair<NT, int> pbpair
                             = P.line_positive_intersect(_p, _v, _lambdas, _Av, _lambda_prev,
-                                                        _AA, _update_parameters);
+                                                        _AA, _update_parameters); //
                     if (T <= pbpair.first) {
-                        _p += (T * _v);
+                        _p += (T * _v);//
                         _lambda_prev = T;
                         break;
                     }
                     _lambda_prev = dl * pbpair.first;
-                    _p += (_lambda_prev * _v);
+                    _p += (_lambda_prev * _v);//
                     T -= _lambda_prev;
-                    P.compute_reflection(_v, _p, _update_parameters);
+                    P.compute_reflection(_v, _p, _update_parameters);//
                     it++;
                 }
                 if (it == _rho) {

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -152,7 +152,7 @@ struct AcceleratedBilliardWalk
                     _p += (_lambda_prev * _v);
                 }
                 T -= _lambda_prev;
-                P.compute_reflection(_v, _p, _update_parameters);
+                P.compute_reflection_abw(_v, _p, _update_parameters);
                 it++;
 
                 while (it < _rho)
@@ -177,7 +177,7 @@ struct AcceleratedBilliardWalk
                         _p += (_lambda_prev * _v);
                     }
                     T -= _lambda_prev;
-                    P.compute_reflection(_v, _p, _update_parameters);
+                    P.compute_reflection_abw(_v, _p, _update_parameters);
                     it++;
                 }
                 _p += _update_parameters.moved_dist * _v;
@@ -298,7 +298,7 @@ struct AcceleratedBilliardWalk
             _lambda_prev = dl * pbpair.first;
             _p += (_lambda_prev * _v);
             T -= _lambda_prev;
-            P.compute_reflection(_v, _p, _update_parameters);
+            P.compute_reflection_abw(_v, _p, _update_parameters);
 
             while (it <= _rho)
             {
@@ -316,7 +316,7 @@ struct AcceleratedBilliardWalk
                 _lambda_prev = dl * pbpair.first;
                 _p += (_lambda_prev * _v);
                 T -= _lambda_prev;
-                P.compute_reflection(_v, _p, _update_parameters);
+                P.compute_reflection_abw(_v, _p, _update_parameters);
                 it++;
             }
         }

--- a/include/random_walks/uniform_accelerated_billiard_walk.hpp
+++ b/include/random_walks/uniform_accelerated_billiard_walk.hpp
@@ -65,7 +65,7 @@ public:
         heap_size = 0;
         for(int i = 0; i < n; ++i) {
             vec[i].second = -1;
-            if(vec[i].first > moved_dist) {
+            if(vec[i].first - eps > moved_dist) {
                 vec[i].second = heap_size;
                 heap[heap_size++] = {vec[i].first, i};
             }
@@ -83,7 +83,8 @@ public:
         return heap[0];
     }
 
-    void remove (int index) { // takes the index from the heap
+    void remove (int index) { // takes the index from the vec
+        index = vec[index].second;
         if(index == -1) {
             return;
         }
@@ -96,24 +97,26 @@ public:
     }
 
     void insert (const std::pair<NT, int> val) {
+        vec[val.second].second = heap_size;
+        vec[val.second].first = val.first;
         heap[heap_size++] = val;
         siftUp(heap_size - 1);
     }
 
     void change_val(const int& index, const NT& new_val, const NT& moved_dist) { // takes the index from the vec
-        if(new_val < moved_dist) { // should not be inserted into the heap
-            remove(vec[index].second);
-        } else { // should be inserted into the heap
+        if(new_val < moved_dist - eps) {
+            vec[index].first = new_val;
+            remove(index);
+        } else {
             if(vec[index].second == -1) {
-                vec[index].second = heap_size;
                 insert({new_val, index});
             } else {
                 heap[vec[index].second].first = new_val;
+                vec[index].first = new_val;
                 siftDown(vec[index].second);
                 siftUp(vec[index].second);
             }
         }
-        vec[index].first = new_val;
     }
 };
 

--- a/test/sampling_test.cpp
+++ b/test/sampling_test.cpp
@@ -399,7 +399,7 @@ template <typename NT>
 void call_test_sparse(){
     typedef Cartesian<NT>    Kernel;
     typedef typename Kernel::Point    Point;
-    typedef HPolytope<Point, Eigen::SparseMatrix<NT>> Hpolytope;
+    typedef HPolytope<Point, Eigen::SparseMatrix<NT, Eigen::RowMajor>> Hpolytope;
     typedef typename Hpolytope::MT MT;
     typedef typename Hpolytope::DenseMT DenseMT;
     typedef Eigen::Matrix<NT,Eigen::Dynamic,1> VT;


### PR DESCRIPTION
optimized the complexity of the reflection when the A matrix is sparse

Sampled 1000 points from the same order polytope with the same seed using both sparse and dense abw, here are the last 2 points:
Dense: 
   0.947133     0.13444    0.417853    0.499325    0.995814    0.775422    0.728527    0.715522   0.0377974    0.428896
   0.708553    0.119995    0.224509    0.549352    0.919391    0.649939    0.648627     0.55607   0.0863634    0.500581

Sparse:
   0.947133     0.13444    0.417853    0.499325    0.995814    0.775422    0.728527    0.715522   0.0377974    0.428896
   0.708553    0.119995    0.224509    0.549352    0.919391    0.649939    0.648627     0.55607   0.0863634    0.500581


[points_sparse.txt](https://github.com/user-attachments/files/16634930/points_sparse.txt)
[points_dense.txt](https://github.com/user-attachments/files/16634931/points_dense.txt)
