### PR TITLE
#193: Update Python Dependency to Python3 in CMakeLists.txt for EnvelopeProblemSOS

### DIFF
--- a/examples/EnvelopeProblemSOS/CMakeLists.txt
+++ b/examples/EnvelopeProblemSOS/CMakeLists.txt
@@ -52,7 +52,8 @@ if (USE_OpenMP)
     find_package(OpenMP REQUIRED)
 endif (USE_OpenMP)
 
-find_package(Python2 COMPONENTS Development NumPy)
+find_package(Python3 COMPONENTS Development NumPy REQUIRED)
+
 add_executable(EnvelopeProblem ${TARGETS})
 
 if (NOT BOOST_DIR)
@@ -82,5 +83,6 @@ else ()
     if (USE_OpenMP)
         target_link_directories(EnvelopeProblem PRIVATE ${OPENMP_LIBRARIES})
     endif ()
-    target_link_libraries(EnvelopeProblem Python2::Python Python2::NumPy)
+    target_link_libraries(EnvelopeProblem Python3::Python Python3::NumPy)
+
 endif ()


### PR DESCRIPTION
This pull request updates the CMakeLists.txt file for the EnvelopeProblemSOS example to use Python3 instead of Python2. Since Python2 is no longer officially supported and many systems default to Python3, this change is intended to make it easier for contributors to build and work with this project.

Changes Made:

🔹Updated CMakeLists.txt to find and link Python3 instead of Python2:
         🔹Replaced find_package(Python2 COMPONENTS Development NumPy) with find_package(Python3 
             COMPONENTS Development NumPy REQUIRED).
           🔹Replaced target_link_libraries(EnvelopeProblem Python2::Python Python2::NumPy) with 
              target_link_libraries(EnvelopeProblem Python3::Python Python3::NumPy).
              
 Why this is needed:

1.Python2 has reached end-of-life, so this removes the need for contributors to set up legacy dependencies.
2.Compatibility: This update makes building the project simpler for anyone using modern systems.
3.Long-term maintenance: Staying up-to-date with Python3 ensures fewer issues going forward and makes it easier for new developers to jump in.

I’ve tested these changes to make sure the example builds successfully with Python3, and everything seems to be working smoothly.