### PR TITLE
Fix CMake warning CMAKE_MINIMUM_REQUIRED

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,11 +7,11 @@
 # Contributed and/or modified by Ioannis Iakovidis
 # Licensed under GNU LGPL.3, see LICENCE file
 
+CMAKE_MINIMUM_REQUIRED(VERSION 3.11)
+
 project( VolEsti )
 
 enable_testing()
-
-CMAKE_MINIMUM_REQUIRED(VERSION 3.11)
 
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 


### PR DESCRIPTION
# Fix CMake warning about minimum_required declaration order

## Issue
This PR fixes issue #341 where a CMake warning is triggered due to improper ordering of CMake commands.

## Changes
- Moved `CMAKE_MINIMUM_REQUIRED(VERSION 3.11)` before the `project(VolEsti)` declaration in test/CMakeLists.txt
- No functional changes, only fixing the warning

## Details
CMake best practices require that the minimum required version be declared before the project definition. This ensures proper policy settings and behavior consistency. This PR makes the minimal necessary change to fix the warning while maintaining project conventions.

Closes #341