### PR TITLE
Fix RK4 stage weighting to keep amplitude bounded

### DIFF
--- a/include/ode_solvers/runge_kutta.hpp
+++ b/include/ode_solvers/runge_kutta.hpp
@@ -103,7 +103,7 @@ struct RKODESolver {
         // Calculate k_i s
         y = F(i,ks[ord], t);
         ks[ord][i] = y;
-        y = (eta * bs[i]) * y;
+        y = (eta * bs[ord]) * y;
 
         if (Ks[i] == NULL) {
           xs[i] = xs[i] + y;


### PR DESCRIPTION
Resolves a bug in Runge-Kutta.
Changed the Runge–Kutta solver so each stage uses the right weight (bs[ord]) instead of the state index. This stops the 
x'' = -x simulation from gaining energy and keeps the sine solution bounded.