### PR TITLE
Improve build and run instructions for hpolytope-volume example

### DIFF
--- a/examples/hpolytope-volume/README.md
+++ b/examples/hpolytope-volume/README.md
@@ -1,14 +1,27 @@
 ## Compilation
-Build the example by running the following commands in this directory.
+
+This example demonstrates how to compute the volume of an H-polytope
+using different randomized algorithms provided by volesti.
+
+It is recommended to build the example using an out-of-source build.
 
 ```bash
-cmake . -DLP_SOLVE=_PATH_TO_LIB_FILE
-make
+mkdir build
+cd build
+cmake ..
+make -j$(nproc)
 ```  
-You have to specify the path to liblpsolve55.so/dll/dylib.  
-For example: -DLP_SOLVE=/usr/lib/lpsolve/liblpsolve55.so
+Alternatively, a local installation of lp_solve can be specified explicitly:
+```bash
+cmake .. -DLP_SOLVE=/path/to/liblpsolve55.so
+```
 
-## Running:
+## Running
+
+After a successful build, run the executable with:
 ```bash
  ./hpolytopeVolume
 ```
+The program computes the volume of a 4-dimensional H-polytope using
+different randomized algorithms. Due to the randomized nature of the
+methods, results may vary slightly between different runs.


### PR DESCRIPTION
### Summary

This pull request improves the **README documentation** for the
`examples/hpolytope-volume` example in **volesti**.

### What was changed

- Added a short explanation of the *purpose of the example*
- Updated build instructions to use an **out-of-source build**, which is the
  recommended CMake workflow
- Documented how to optionally specify a **local `lp_solve` installation**
- Added clear instructions for **running the example after compilation**

### Motivation

The previous instructions required manual configuration and could be
confusing for *new users*. These changes make the example **easier to build
and run**, especially for first-time users of **volesti**, without changing
any existing code or behavior.
