### PR TITLE
Add boundary oracle to integral collocation solver

### DIFF
--- a/include/ode_solvers/integral_collocation.hpp
+++ b/include/ode_solvers/integral_collocation.hpp
@@ -17,12 +17,16 @@
 #ifndef ODE_SOLVERS_INTEGRAL_COLLOCATION_HPP
 #define ODE_SOLVERS_INTEGRAL_COLLOCATION_HPP
 
+#include <cmath>
+#include <limits>
+
 #include "nlp_oracles/nlp_hpolyoracles.hpp"
 #include "nlp_oracles/nlp_vpolyoracles.hpp"
 #include "boost/numeric/ublas/vector.hpp"
 #include "boost/numeric/ublas/io.hpp"
 #include "boost/math/special_functions/chebyshev.hpp"
 #include "boost/math/special_functions/chebyshev_transform.hpp"
+#include "root_finders/mp_solve_wrapper.hpp"
 
 template <
     typename Point,
@@ -74,6 +78,22 @@ struct IntegralCollocationODESolver {
 
   int prev_facet = -1;
   Point prev_point;
+
+  Point evaluate_polynomial(const pts &coefficients, NT value) const {
+    if (coefficients.empty()) {
+      return Point(dim);
+    }
+
+    Point result(coefficients[0].dimension());
+    NT current_power = NT(1);
+
+    for (const Point &coeff : coefficients) {
+      result += coeff * current_power;
+      current_power *= value;
+    }
+
+    return result;
+  }
 
   IntegralCollocationODESolver(NT initial_time, NT step, pts initial_state,
     func oracle, bounds boundaries, unsigned int order_=4) :
@@ -210,50 +230,97 @@ struct IntegralCollocationODESolver {
         }
       }
       else {
-        throw true;
-        // TODO Implement oracle. It requires doing chebyshev transforms
-        // with the same #of points at each dimension
-        // 1. Temporarily store coefficients as points
-        // 2. Initialize everything to Points at origin (for zero-padding)
-        // pts temp_pts(max_transform_coeffs_length, Point(dim));
+        if (max_transform_coeffs_length == 0) {
+          for (unsigned int j = i * dim; j < (i + 1) * dim; j++) {
+            xs[i].set_coord(j % dim, X_op(j));
+          }
+          continue;
+        }
 
-        // 3. Store transformation to polynomial of twice the degree
-        // pts transformed_pts(2 * max_transform_coeffs_length, Point(dim));
-        // std::vector<NT> temp_coeffs;
+        // Build a polynomial representation of the trajectory on [0, eta].
+        pts chebyshev_coeffs(max_transform_coeffs_length, Point(dim));
+        for (unsigned int coord = 0; coord < dim; coord++) {
+          unsigned int transform_index = i * dim + coord;
+          std::vector<NT> temp_coeffs = transforms[transform_index].coefficients();
+          for (unsigned int k = 0; k < temp_coeffs.size(); k++) {
+            chebyshev_coeffs[k].set_coord(coord, temp_coeffs[k]);
+          }
+        }
 
-        // 4. Invoke chebyshev transform coefficients
-        // Precomputed from the final step of the fixed point iterator
-        // for (unsigned int j = i * dim; j < (i + 1) * dim; j++) {
-        //   temp_coeffs = transforms[j].coefficients();
-        //   for (unsigned int k = 0; k < temp_coeffs.size(); k++) {
-        //     temp_pts[k].set_coord(j % dim, temp_coeffs[k]);
-        //   }
-        // }
+        unsigned int doubled_length = 2 * (max_transform_coeffs_length - 1) + 1;
+        pts trajectory_coeffs(doubled_length, Point(dim));
+        degree_doubling_chebyshev(chebyshev_coeffs, trajectory_coeffs);
 
-        // 5. Apply degree-doubling transformation
-        // The transformation takes the n Chebyshev transform coefficients c[i]
-         // and creates a complex polynomial of order 2n with coefficients a[i]
-        // such that a[n] = 2 * c[0], a[i] = c[i - n] for i > n and a[i] = c[n - i] for i < n
-        // This polynomial h(z) is defined on the complex plane.
-        // Its roots are related to the chebyshev transform as: z is a root of
-        // the degree-doubled polynomial h(z) then Re(z) is a
-        // root for the chebyshev transfrom. This transformation is domain_name
-        // in order to be able to use MPSolve to compute the boundary oracle
-        // degree_doubling_chebyshev(temp_pts, transformed_pts);
+        trajectory_coeffs.insert(trajectory_coeffs.begin(), Point(dim));
+        for (unsigned int k = 1; k < trajectory_coeffs.size(); k++) {
+          trajectory_coeffs[k] = (NT(1) / NT(k)) * trajectory_coeffs[k];
+        }
+        trajectory_coeffs[0] = xs_prev[i];
 
-        // 6. Integrate coefficients
-        // We want the integral of the function instead of the function itself.
-        // Integrating the polynomial is fairly easy.
-        // transformed_pts.insert(transformed_pts.begin(), Point(dim));
+        Point candidate_point = evaluate_polynomial(trajectory_coeffs, eta);
 
-        // for (unsigned int k = 1; k < transformed_pts.size(); k++) {
-          // transformed_pts[k] = (1.0 / k) * transformed_pts[k];
-        // }
+        if (Ks[i]->is_in(candidate_point, tol) == -1) {
+          xs[i] = candidate_point;
+          prev_facet = -1;
+          continue;
+        }
 
-        // 7. Find roots using MPSolve
-        // Project the computed coefficients to each of the polytopes normals and
-        // calculate the complex roots of the resulting equations.
-        // Then keep the smallest positive rational part.
+        MT A_bound = Ks[i]->get_mat();
+        VT b_bound = Ks[i]->get_vec();
+        NT best_time = eta;
+        Point best_point = candidate_point;
+        int best_facet = -1;
+        const NT boundary_tol = NT(1e-5);
+        const NT root_tol = NT(1e-9);
+
+        // Project the polynomial on each facet normal and locate the earliest hit.
+        for (int facet = 0; facet < A_bound.rows(); facet++) {
+          std::vector<NT> projected(trajectory_coeffs.size(), NT(0));
+          for (unsigned int deg = 0; deg < trajectory_coeffs.size(); deg++) {
+            projected[deg] = A_bound.row(facet) * trajectory_coeffs[deg].getCoefficients();
+          }
+          projected[0] -= b_bound(facet);
+
+          auto roots = mpsolve<NT>(projected);
+          for (auto &root : roots) {
+            NT candidate_time = root.first;
+            if (candidate_time < root_tol || candidate_time > eta + tol) continue;
+
+            Point intersection = evaluate_polynomial(trajectory_coeffs, candidate_time);
+            NT facet_value = A_bound.row(facet) * intersection.getCoefficients() - b_bound(facet);
+
+            if (std::abs(facet_value) > boundary_tol) continue;
+            if (Ks[i]->is_in(intersection, boundary_tol) == 0) continue;
+
+            if (candidate_time < best_time) {
+              best_time = candidate_time;
+              best_point = intersection;
+              best_facet = facet;
+            }
+          }
+        }
+
+        if (best_facet != -1) {
+          Point offset = best_point - xs_prev[i];
+          xs[i] = xs_prev[i] + NT(0.99) * offset;
+          prev_point = best_point;
+          prev_facet = best_facet;
+        } else {
+          Point direction = candidate_point - xs_prev[i];
+          NT direction_norm = direction.getCoefficients().squaredNorm();
+          if (direction_norm < tol) {
+            xs[i] = xs_prev[i];
+          } else {
+            std::pair<NT, NT> line_hit = Ks[i]->line_intersect(xs_prev[i], direction);
+            NT lambda = line_hit.first;
+            if (lambda < std::numeric_limits<NT>::max()) {
+              xs[i] = xs_prev[i] + (direction * (NT(0.99) * lambda));
+            } else {
+              xs[i] = candidate_point;
+            }
+          }
+          prev_facet = -1;
+        }
       }
 
     }


### PR DESCRIPTION
 ## Summary
  - rebuild the Chebyshev-integrated trajectory as a monomial polynomial so it can be evaluated anywhere inside the step
  - project that polynomial onto each H-polytope facet and use the existing MPSolve wrapper to locate the earliest
  boundary hit
  - keep unconstrained paths on the old code path and add a fallback line clip if the polynomial solver cannot find a
  valid root

  ## Testing

  cd test/build
  cmake ..
  make -j$(sysctl -n hw.logicalcpu)   # stops in mmcs_test (known upstream issue)
  ctest -R boundary_oracles --output-on-failure
  
  ### Output
  Start 27: boundary_oracles_test_h_poly_oracles
  1/1 Test #27: boundary_oracles_test_h_poly_oracles ...   Passed    0.85 sec

  100% tests passed, 0 tests failed out of 1

  Total Test time (real) =   0.86 sec