### PR TITLE
Fix: starting_point argument in sample_points() not functional for Ball Walk (BaW)

### DIFF
--- a/include/random_walks/uniform_ball_walk.hpp
+++ b/include/random_walks/uniform_ball_walk.hpp
@@ -79,7 +79,7 @@ struct BallWalk
                                                           _delta,
                                                           rng);
                 y += p;
-                if (P.is_in(y) == -1) p = y;
+                if (P.is_in(y) != -1) p = y;
             }
         }
 


### PR DESCRIPTION
### Problem Description

Issue **#367** reports that when using the **Ball Walk (BaW)** random walk in `sample_points()` with a user-provided `starting_point`, the Markov chain does not evolve and all returned samples remain identical to the starting point.

Minimal reproducible example from the issue:

```r
library(volesti)
P = gen_cube(3, 'H')

point = sample_points(P, n = 1,
        random_walk = list(walk = "BaW", walk_length = 5))

sample_points(P, n = 10,
        random_walk = list(
          walk = "BaW",
          walk_length = 5,
          starting_point = point
        ))
```

Observed behavior:
- All returned columns are identical
- The random walk remains fixed at starting_point
- Increasing walk_length has no effect

This prevents running multiple chains from different initial states and makes convergence diagnostics impossible.

**Investigation and Root Cause Analysis**
The issue was investigated by tracing the full data flow of `starting_point` from the R interface to the C++ backend:

**1.R interface** (`sample_points`)
Verified that `starting_point` is correctly passed from R to C++.

**2.Sampling dispatcher** (`include/sampling/sampling.hpp`)
Confirmed that:
- `Point p = starting_point;` is initialized once
- The walk state is passed by reference
- The state is not reset per iteration
This ruled out incorrect state initialization.

**3.Ball Walk implementation** (`include/random_walks/uniform_ball_walk.hpp`)
The acceptance logic in `Walk::apply()` was identified as:
```r
if (P.is_in(y) == -1) p = y;
```

Here, `P.is_in(y) == -1` indicates that the proposed point lies outside the polytope.

**Why This Caused the Bug**
Ball Walk semantics require accepting a proposal **only if it lies inside the polytope.**

However, the existing logic:

- Accepted only outside points
- Rejected all valid interior proposals
- Prevented the walk state from ever updating

As a result, the chain remained frozen at the provided starting_point, exactly matching the behavior reported in **#367**.

**Fix**
The acceptance condition was corrected to accept points inside (or on the boundary of) the polytope:
```r
- if (P.is_in(y) == -1) p = y;
+ if (P.is_in(y) != -1) p = y;
```

**Result**
After this change:
- The Ball Walk evolves correctly from a user-provided **starting_point**
- **walk_length** properly affects chain movement
- Multiple independent chains can be initialized from different starting points
- Behavior aligns with standard Ball Walk and MCMC semantics

**Scope of Change**
- Single-line logic fix
- No API changes
- No impact on other random walks
- Fully backward-compatible

Fixes #367