### PR TITLE
docs(diagnostics): clarify assumptions and complexity of ESS estimation

### DIFF
--- a/include/diagnostics/effective_sample_size.hpp
+++ b/include/diagnostics/effective_sample_size.hpp
@@ -8,6 +8,18 @@
 
 // Licensed under GNU LGPL.3, see LICENCE file
 
+// Effective Sample Size (ESS) estimation using FFT-based autocorrelation.
+//
+// Assumptions:
+//  - Samples are post burn-in and approximately stationary
+//  - Columns correspond to consecutive samples of a single chain
+//  - Number of samples N >= 2
+//
+// Notes:
+//  - ESS is estimated independently per dimension
+//  - Constant or nearly constant chains will result in ESS ≈ 1
+//  - Computation is O(N log N) per dimension due to FFT
+
 #include <unsupported/Eigen/FFT>
 
 #ifndef DIAGNOSTICS_EFFECTIVE_SAMPLE_SIZE_HPP


### PR DESCRIPTION
While reviewing the diagnostics code, I noticed that `effective_sample_size` relies on several implicit assumptions (stationarity, single-chain layout, minimum sample size) that are not currently documented.
This PR adds a concise documentation block explaining the intended usage, assumptions, and computational complexity of the ESS estimator, without changing any behavior.
The goal is to make the diagnostics layer easier to understand for new contributors and users.