### PR TITLE
Add RK4 oscillatory stability regression test (reproduces #120)

### DIFF
--- a/include/diagnostics/effective_sample_size.hpp
+++ b/include/diagnostics/effective_sample_size.hpp
@@ -8,6 +8,18 @@
 
 // Licensed under GNU LGPL.3, see LICENCE file
 
+// Effective Sample Size (ESS) estimation using FFT-based autocorrelation.
+//
+// Assumptions:
+//  - Samples are post burn-in and approximately stationary
+//  - Columns correspond to consecutive samples of a single chain
+//  - Number of samples N >= 2
+//
+// Notes:
+//  - ESS is estimated independently per dimension
+//  - Constant or nearly constant chains will result in ESS ≈ 1
+//  - Computation is O(N log N) per dimension due to FFT
+
 #include <unsupported/Eigen/FFT>
 
 #ifndef DIAGNOSTICS_EFFECTIVE_SAMPLE_SIZE_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -222,6 +222,9 @@ add_executable (billiard_shake_and_bake_test billiard_shake_and_bake_test.cpp $<
 add_test(NAME test_billiard_shake_and_bake COMMAND billiard_shake_and_bake_test -tc=billiard_shake_and_bake)
 
 add_executable (ode_solvers_test ode_solvers_test.cpp $<TARGET_OBJECTS:test_main>)
+add_executable (ode_stiff_test test_ode_stiff.cpp $<TARGET_OBJECTS:test_main>)
+add_test(NAME ode_stiff_test
+        COMMAND ode_stiff_test)
 add_test(NAME ode_solvers_test_first_order
         COMMAND ode_solvers_test -tc=first_order)
 add_test(NAME ode_solvers_test_second_order
@@ -420,6 +423,7 @@ TARGET_LINK_LIBRARIES(benchmarks_cb lp_solve ${MKL_LINK} coverage_config)
 #TARGET_LINK_LIBRARIES(benchmarks_crhmc lp_solve ${MKL_LINK} QD_LIB  coverage_config)
 TARGET_LINK_LIBRARIES(simple_mc_integration lp_solve ${MKL_LINK} coverage_config)
 TARGET_LINK_LIBRARIES(ode_solvers_test lp_solve ${IFOPT} ${IFOPT_IPOPT} ${PTHREAD} ${GMP} ${MPSOLVE} ${FFTW3} ${MKL_LINK} QD_LIB coverage_config)
+TARGET_LINK_LIBRARIES(ode_stiff_test lp_solve ${IFOPT} ${IFOPT_IPOPT} ${PTHREAD} ${GMP} ${MPSOLVE} ${FFTW3} ${MKL_LINK} QD_LIB coverage_config)
 TARGET_LINK_LIBRARIES(boundary_oracles_test lp_solve ${IFOPT} ${IFOPT_IPOPT} ${PTHREAD} ${GMP} ${MPSOLVE} ${FFTW3} ${MKL_LINK} coverage_config)
 TARGET_LINK_LIBRARIES(root_finders_test ${PTHREAD} ${GMP} ${MPSOLVE} ${FFTW3} ${MKL_LINK} coverage_config)
 TARGET_LINK_LIBRARIES(crhmc_polytope_preparation_test ${PTHREAD} ${GMP} ${MPSOLVE} ${FFTW3} ${MKL_LINK} QD_LIB coverage_config)

--- a/test/test_ode_stiff.cpp
+++ b/test/test_ode_stiff.cpp
@@ -1,0 +1,57 @@
+// Regression test for oscillatory ODE stability
+// Reproduces issue#120 and validates fix in PR#375
+
+
+#include "doctest.h"
+#include <iostream>   // REQUIRED for runge_kutta.hpp
+#include <cmath>
+#include <vector>
+
+#include "Eigen/Eigen"
+
+#include "ode_solvers/ode_solvers.hpp"
+#include "generators/known_polytope_generators.h"
+
+TEST_CASE("rk4_oscillator_stability_regression") {
+
+  using NT = double;
+  typedef Cartesian<NT> Kernel;
+  typedef typename Kernel::Point Point;
+  typedef std::vector<Point> pts;
+  typedef HPolytope<Point> Hpolytope;
+  typedef std::vector<Hpolytope*> bounds;
+
+  // x'' = -x  (harmonic oscillator)
+  IsotropicQuadraticFunctor::parameters<NT> params;
+  params.order = 2;
+  params.alpha = 1;
+
+  typedef IsotropicQuadraticFunctor::GradientFunctor<Point> func;
+  func F(params);
+
+  unsigned int dim = 1;
+
+  // Initial conditions: x(0)=0, v(0)=1
+  Point x0(dim);
+  Point v0 = Point::all_ones(dim);
+
+  pts state{x0, v0};
+
+  RKODESolver<Point, NT, Hpolytope, func> solver(
+      0.0,                 // initial time
+      0.05,                // step size
+      state,
+      F,
+      bounds{nullptr, nullptr}
+  );
+
+  const int steps = 2000;
+  const NT amplitude_ub = 1.5;  // exact is 1, keep margin
+
+  for (int i = 0; i < steps; ++i) {
+    solver.step(i, true);
+
+    NT x_norm = std::sqrt(solver.xs[0].dot(solver.xs[0]));
+    CHECK(x_norm < amplitude_ub);
+  }
+}


### PR DESCRIPTION
### Description
Adds a regression test covering oscillatory ODE stability for the RK4 solver.

### Motivation
Issue #120 reported numerical instability for oscillatory systems (x'' = -x), which was fixed in PR #375 by correcting RK4 stage weighting. However, no test existed to guard against future regressions.

### What this PR does
- Adds `ode_stiff_test`
- Verifies bounded amplitude for a harmonic oscillator
- Fails if numerical energy growth reappears

### Related issues
- Reproduces: #120
- Guards fix from: #375
- Resolves: #406 