### PR TITLE
docs(diagnostics): clarify assumptions and limitations of Geweke diag…

### DIFF
--- a/include/diagnostics/geweke.hpp
+++ b/include/diagnostics/geweke.hpp
@@ -26,6 +26,26 @@
             (ii) true if the null hypothesis is not rejected
 */
 
+/* Multivariate Geweke convergence diagnostic using Hotelling's T² test.
+
+Assumptions:
+ - Samples correspond to a *single* MCMC chain
+ - Chain is approximately stationary (post burn-in)
+ - Columns are consecutive samples
+ - frac_first + frac_last < 1
+ - N1 + N2 > d + 1 (required for Fisher F distribution)
+
+Notes:
+ - This is a multivariate extension of Geweke (1992)
+ - The test checks equality of means between early and late chain segments
+ - A return value of `true` does NOT guarantee convergence,
+   only that the null hypothesis was not rejected
+
+Failure modes:
+ - Degenerate or collinear chains may cause covariance inversion to fail
+ - Very small sample sizes may produce unreliable results
+*/
+
 
 #ifndef DIAGNOSTICS_GEWEKE_HPP
 #define DIAGNOSTICS_GEWEKE_HPP


### PR DESCRIPTION
While going through the diagnostics codebase, I reviewed the implementation of the multivariate Geweke diagnostic.
The implementation is correct and well-structured, but relies on several implicit statistical assumptions (stationarity, sample size vs. dimension, fraction constraints) that were not documented.
This PR adds concise documentation clarifying these assumptions and known failure modes, with the goal of helping new contributors and users apply the diagnostic correctly and avoid silent misuse.
No functional changes are introduced.