### PR TITLE
docs(diagnostics): clarify assumptions and limitations of convergence diagnostics

### DIFF
--- a/include/diagnostics/multivariate_psrf.hpp
+++ b/include/diagnostics/multivariate_psrf.hpp
@@ -19,6 +19,34 @@
     Output: The value of multivariate PSRF by S. Brooks and A. Gelman
 */
 
+// Multivariate Potential Scale Reduction Factor (PSRF) diagnostic.
+//
+// This implements the Brooks & Gelman (1998) multivariate PSRF by
+// splitting a single MCMC chain into two consecutive segments and
+// comparing within-chain and between-segment covariance structure.
+//
+// Assumptions:
+//  - Samples correspond to a *single* MCMC chain
+//  - Chain is approximately stationary (post burn-in)
+//  - Columns are consecutive samples
+//  - Number of samples N is sufficiently larger than dimension d
+//  - Within-chain covariance matrix is invertible
+//
+// Interpretation:
+//  - Values close to 1 indicate potential convergence
+//  - Larger values suggest lack of convergence or poor mixing
+//  - As with univariate PSRF, this is a heuristic diagnostic
+//
+// Notes:
+//  - This is a single-chain adaptation via chain splitting
+//  - The largest eigenvalue of W^{-1} B drives the diagnostic
+//  - Passing this diagnostic does not imply correctness of the target distribution
+//
+// Failure modes:
+//  - Near-singular covariance matrices may cause numerical instability
+//  - Highly autocorrelated or multimodal chains may pass spuriously
+//  - Small sample sizes relative to dimension lead to unreliable results
+
 #ifndef DIAGNOSTICS_PSRF_HPP
 #define DIAGNOSTICS_PSRF_HPP
 

--- a/include/diagnostics/raftery.hpp
+++ b/include/diagnostics/raftery.hpp
@@ -25,6 +25,38 @@
              (vi)  The I-statistic from Raftery and Lewis (1992)
 */
 
+// Raftery–Lewis diagnostic for required sample size estimation.
+//
+// Purpose:
+//  - Estimates the number of iterations needed to estimate a quantile
+//    q with precision r and probability s.
+//
+// Important:
+//  - This is NOT a general convergence diagnostic
+//  - It does not test stationarity or mixing directly
+//
+// Assumptions:
+//  - Samples come from a single, stationary MCMC chain
+//  - Chain can be approximated as first-order Markov after thinning
+//  - Target is estimation of a *quantile*, not full distribution
+//
+// Outputs (per dimension):
+//  [0] k_thin   : thinning factor for approximate Markov property
+//  [1] n_burn   : estimated burn-in length
+//  [2] k_ind    : thinning for approximate independence
+//  [3] n_total  : total draws required (burn-in + sampling)
+//  [4] n_min    : draws required if samples were IID
+//  [5] I_stat   : inefficiency factor (ratio vs IID)
+//
+// Interpretation:
+//  - Large I_stat indicates strong autocorrelation
+//  - Results should be interpreted as *guidelines*, not guarantees
+//
+// Limitations:
+//  - Sensitive to choice of q, r, s
+//  - Unreliable for multimodal or poorly mixing chains
+//  - Not suitable as a standalone convergence test
+
 #ifndef DIAGNOSTICS_RAFTERY_HPP
 #define DIAGNOSTICS_RAFTERY_HPP
 

--- a/include/diagnostics/univariate_psrf.hpp
+++ b/include/diagnostics/univariate_psrf.hpp
@@ -19,6 +19,31 @@
     Output: The value of PSRF of D.B. Rubin and A. Gelman for each coordinate
 */
 
+// Univariate Potential Scale Reduction Factor (PSRF) diagnostic.
+//
+// This implements the original Rubin & Gelman (1992) PSRF for a *single*
+// MCMC chain by splitting it into two consecutive segments.
+//
+// Assumptions:
+//  - Samples correspond to a single MCMC chain
+//  - Chain is approximately stationary (post burn-in)
+//  - Columns are consecutive samples
+//  - Number of samples N >= 4
+//
+// Interpretation:
+//  - PSRF values close to 1 indicate potential convergence
+//  - Values significantly larger than 1 suggest lack of convergence
+//  - A common heuristic is PSRF < 1.1, but this is not a guarantee
+//
+// Notes:
+//  - This is a single-chain variant obtained by splitting the chain in half
+//  - It does NOT detect multimodality or poor mixing reliably
+//  - Passing PSRF does not imply correctness of the target distribution
+//
+// Limitations:
+//  - Highly autocorrelated chains may produce misleadingly small PSRF
+//  - Very short chains lead to unstable variance estimates
+
 #ifndef DIAGNOSTICS_MARGINAL_PSRF_HPP
 #define DIAGNOSTICS_MARGINAL_PSRF_HPP
 


### PR DESCRIPTION
While reviewing the diagnostics module, I added concise documentation to clarify the assumptions, interpretation, and limitations of several MCMC convergence diagnostics (univariate PSRF, multivariate PSRF, and Raftery–Lewis).
The goal is to make the expected usage and failure modes explicit for new contributors and users, without changing any existing behavior or algorithms.
This PR is documentation-only and does not modify numerical results or APIs.