### PR TITLE
Fix silent failure in compute_feasible_point

### DIFF
--- a/include/diagnostics/multivariate_psrf.hpp
+++ b/include/diagnostics/multivariate_psrf.hpp
@@ -19,6 +19,34 @@
     Output: The value of multivariate PSRF by S. Brooks and A. Gelman
 */
 
+// Multivariate Potential Scale Reduction Factor (PSRF) diagnostic.
+//
+// This implements the Brooks & Gelman (1998) multivariate PSRF by
+// splitting a single MCMC chain into two consecutive segments and
+// comparing within-chain and between-segment covariance structure.
+//
+// Assumptions:
+//  - Samples correspond to a *single* MCMC chain
+//  - Chain is approximately stationary (post burn-in)
+//  - Columns are consecutive samples
+//  - Number of samples N is sufficiently larger than dimension d
+//  - Within-chain covariance matrix is invertible
+//
+// Interpretation:
+//  - Values close to 1 indicate potential convergence
+//  - Larger values suggest lack of convergence or poor mixing
+//  - As with univariate PSRF, this is a heuristic diagnostic
+//
+// Notes:
+//  - This is a single-chain adaptation via chain splitting
+//  - The largest eigenvalue of W^{-1} B drives the diagnostic
+//  - Passing this diagnostic does not imply correctness of the target distribution
+//
+// Failure modes:
+//  - Near-singular covariance matrices may cause numerical instability
+//  - Highly autocorrelated or multimodal chains may pass spuriously
+//  - Small sample sizes relative to dimension lead to unreliable results
+
 #ifndef DIAGNOSTICS_PSRF_HPP
 #define DIAGNOSTICS_PSRF_HPP
 

--- a/include/diagnostics/raftery.hpp
+++ b/include/diagnostics/raftery.hpp
@@ -25,6 +25,38 @@
              (vi)  The I-statistic from Raftery and Lewis (1992)
 */
 
+// Raftery–Lewis diagnostic for required sample size estimation.
+//
+// Purpose:
+//  - Estimates the number of iterations needed to estimate a quantile
+//    q with precision r and probability s.
+//
+// Important:
+//  - This is NOT a general convergence diagnostic
+//  - It does not test stationarity or mixing directly
+//
+// Assumptions:
+//  - Samples come from a single, stationary MCMC chain
+//  - Chain can be approximated as first-order Markov after thinning
+//  - Target is estimation of a *quantile*, not full distribution
+//
+// Outputs (per dimension):
+//  [0] k_thin   : thinning factor for approximate Markov property
+//  [1] n_burn   : estimated burn-in length
+//  [2] k_ind    : thinning for approximate independence
+//  [3] n_total  : total draws required (burn-in + sampling)
+//  [4] n_min    : draws required if samples were IID
+//  [5] I_stat   : inefficiency factor (ratio vs IID)
+//
+// Interpretation:
+//  - Large I_stat indicates strong autocorrelation
+//  - Results should be interpreted as *guidelines*, not guarantees
+//
+// Limitations:
+//  - Sensitive to choice of q, r, s
+//  - Unreliable for multimodal or poorly mixing chains
+//  - Not suitable as a standalone convergence test
+
 #ifndef DIAGNOSTICS_RAFTERY_HPP
 #define DIAGNOSTICS_RAFTERY_HPP
 

--- a/include/diagnostics/univariate_psrf.hpp
+++ b/include/diagnostics/univariate_psrf.hpp
@@ -19,6 +19,31 @@
     Output: The value of PSRF of D.B. Rubin and A. Gelman for each coordinate
 */
 
+// Univariate Potential Scale Reduction Factor (PSRF) diagnostic.
+//
+// This implements the original Rubin & Gelman (1992) PSRF for a *single*
+// MCMC chain by splitting it into two consecutive segments.
+//
+// Assumptions:
+//  - Samples correspond to a single MCMC chain
+//  - Chain is approximately stationary (post burn-in)
+//  - Columns are consecutive samples
+//  - Number of samples N >= 4
+//
+// Interpretation:
+//  - PSRF values close to 1 indicate potential convergence
+//  - Values significantly larger than 1 suggest lack of convergence
+//  - A common heuristic is PSRF < 1.1, but this is not a guarantee
+//
+// Notes:
+//  - This is a single-chain variant obtained by splitting the chain in half
+//  - It does NOT detect multimodality or poor mixing reliably
+//  - Passing PSRF does not imply correctness of the target distribution
+//
+// Limitations:
+//  - Highly autocorrelated chains may produce misleadingly small PSRF
+//  - Very short chains lead to unstable variance estimates
+
 #ifndef DIAGNOSTICS_MARGINAL_PSRF_HPP
 #define DIAGNOSTICS_MARGINAL_PSRF_HPP
 

--- a/include/preprocess/feasible_point.hpp
+++ b/include/preprocess/feasible_point.hpp
@@ -13,6 +13,7 @@
 #define FEASIBLE_POINT_HPP
 
 #include <tuple>
+#include <stdexcept>
 
 #include "preprocess/max_inscribed_ball.hpp"
 #include "sampling/sphere.hpp" 
@@ -30,7 +31,7 @@ VT compute_feasible_point(MT const& A, VT const& b)
     std::tie(x, std::ignore, converged) = max_inscribed_ball(A, b, max_iters, 1e-08, feasibility_only);
     if (!converged || ((A * x).array() > b.array()).any())
     {
-        std::runtime_error("The computation of a feasible point failed.");
+        throw std::runtime_error("The computation of a feasible point failed.");
     }
     return x;
 }

--- a/include/sampling/mmcs.hpp
+++ b/include/sampling/mmcs.hpp
@@ -5,6 +5,37 @@
 
 // Licensed under GNU LGPL.3, see LICENCE file
 
+/*
+ Multiphase Monte Carlo Sampling (MMCS) interface.
+
+ This header implements the MMCS algorithm used to generate samples
+ with a prescribed effective sample size (ESS) from a convex polytope.
+
+ High-level overview:
+  - MMCS proceeds in phases
+  - Each phase generates correlated samples via a random walk
+  - ESS is estimated online using sliding windows
+  - Optional rounding is applied between phases to improve conditioning
+
+ Role in the sampling pipeline:
+  - Coordinates sampling, ESS estimation, and rounding
+  - Uses diagnostics internally (ESS window estimator)
+  - Produces samples in the original (unrounded) space
+
+ Important assumptions:
+  - The polytope is full-dimensional and bounded
+  - A feasible starting point exists
+  - ESS estimates are approximate and heuristic
+
+ Notes:
+  - MMCS targets *effective* sample size, not raw sample count
+  - Termination depends on ESS estimates, not exact convergence
+  - Diagnostics used here should be interpreted conservatively
+
+ This layer contains algorithmic control logic and intentionally
+ delegates random-walk behavior to WalkTypePolicy.
+*/
+
 #ifndef MMCS_HPP
 #define MMCS_HPP
 

--- a/include/sampling/random_point_generators.hpp
+++ b/include/sampling/random_point_generators.hpp
@@ -5,6 +5,39 @@
 
 // Licensed under GNU LGPL.3, see LICENCE file
 
+/*
+ Random Point Generator utilities for VolEsti.
+
+ This header defines a collection of *generator adapters* that bridge
+ random walk implementations with sampling routines.
+
+ Role in the architecture:
+  - Generators are thin wrappers around Walk types
+  - They are responsible for:
+      • constructing the walk
+      • advancing it for a fixed number of steps
+      • extracting points from the walk state
+      • delegating storage via a WalkPolicy (e.g. PushBack)
+
+ Design principles:
+  - Generators are stateless
+  - No convergence or correctness guarantees are provided here
+  - All diagnostics must be applied externally
+  - Memory ownership is delegated to the caller
+
+ Important assumptions:
+  - The provided starting point is feasible
+  - The polytope is bounded (unless explicitly stated otherwise)
+  - Walk parameters are valid for the chosen walk type
+
+ Notes:
+  - Different generators correspond to different target measures
+    (uniform, Gaussian, log-concave, exponential, boundary sampling)
+  - Failure handling is walk-specific (some walks throw, others return flags)
+
+ This layer intentionally contains no statistical logic.
+*/
+
 #ifndef SAMPLERS_RANDOM_POINT_GENERATORS_HPP
 #define SAMPLERS_RANDOM_POINT_GENERATORS_HPP
 

--- a/include/sampling/sampling.hpp
+++ b/include/sampling/sampling.hpp
@@ -18,6 +18,20 @@
 // Public License.  If you did not receive this file along with HeaDDaCHe,
 // see <http://www.gnu.org/licenses/>.
 
+/*
+ Sampling interface for VolEsti.
+
+ This header provides high-level sampling routines that:
+  - generate correlated samples from convex polytopes
+  - rely on underlying random walk policies
+  - handle burn-in and sample collection
+
+ Design notes:
+  - Sampling functions assume bounded polytopes
+  - Starting points must be feasible
+  - No convergence guarantees are provided here;
+    diagnostics must be applied externally
+*/
 
 #ifndef SAMPLE_ONLY_H
 #define SAMPLE_ONLY_H


### PR DESCRIPTION
This PR fixes a bug in `include/preprocess/feasible_point.hpp` where `compute_feasible_point` constructed a `std::runtime_error` on failure without throwing it, resulting in silent failure.

The fix ensures an exception is thrown when feasibility computation fails or when the returned point violates constraints.

Fixes #414

