### PR TITLE
Fix silent failure in max_inscribed_ball and add regression test

### DIFF
--- a/include/preprocess/max_inscribed_ball.hpp
+++ b/include/preprocess/max_inscribed_ball.hpp
@@ -7,6 +7,9 @@
 
 // Licensed under GNU LGPL.3, see LICENCE file
 
+// NOTE:
+// If converge == false, the returned center and radius are invalid
+// and must not be used by downstream code.
 
 #ifndef MAX_INSCRIBED_BALL_HPP
 #define MAX_INSCRIBED_BALL_HPP
@@ -59,13 +62,11 @@ void calcstep(MT const& A, MT const& A_trans, MT const& B,
     }
 }
 
-// Using MT as to deal with both dense and sparse matrices
 template <typename MT, typename VT, typename NT>
 std::tuple<VT, NT, bool>  max_inscribed_ball(MT const& A, VT const& b, 
                                              unsigned int maxiter, NT tol,
                                              const bool feasibility_only = false) 
 {
-    //typedef matrix_computational_operator<MT> mat_op;
     int m = A.rows(), n = A.cols();
     bool converge = false;
 
@@ -95,7 +96,6 @@ std::tuple<VT, NT, bool>  max_inscribed_ball(MT const& A, VT const& b,
 
     for (unsigned int i = 0; i < maxiter; ++i) {
 
-        // KKT residuals
         r1.noalias() = b - (A * x + s + t * e_m);
         r2.noalias() = -A_trans * y;
         r3 = 1.0 - y.sum();
@@ -105,37 +105,33 @@ std::tuple<VT, NT, bool>  max_inscribed_ball(MT const& A, VT const& b,
         r23(n) = r3;
         gap = -r4.sum();
 
-        // relative residual norms and gap
         prif = r1.norm() / (1.0 + bnrm);
         drif = r23.norm() / 10.0;
         rgap = std::abs(b.dot(y) - t) / (1.0 + std::abs(t));
         total_err = std::max(prif, drif);
         total_err = std::max(total_err, rgap);
 
-        // progress output & check stopping
         if ( (total_err < tol && t > 0) || 
              ( t > 0 && ( (std::abs(t - t_prev) <= tol * std::min(std::abs(t), std::abs(t_prev)) ||
                            std::abs(t - t_prev) <= tol) && i > 10) ) ||
              (feasibility_only && t > tol/2.0 && i > 0) )  
         {
-            //converged
             converge = true;
             break;
         }
 
         if ((dt > 10000.0 * bnrm || t > 10000000.0 * bnrm) && i > 20) 
         {
-            //unbounded
             converge = false;
             break;
         }
 
-        // Shur complement matrix
         vec_iter1 = d.data();
         vec_iter3 = s.data();
         vec_iter2 = y.data();
         for (int j = 0; j < m; ++j) {
-            *vec_iter1 = std::min(power_num, (*vec_iter2) / (*vec_iter3));
+            NT denom = std::max((*vec_iter3), NT(1e-14));
+            *vec_iter1 = std::min(power_num, (*vec_iter2) / denom);
             vec_iter1++;
             vec_iter3++;
             vec_iter2++;
@@ -145,7 +141,6 @@ std::tuple<VT, NT, bool>  max_inscribed_ball(MT const& A, VT const& b,
         AtDe.noalias() = AtD * e_m;
         update_Bmat<NT>(B, AtDe, d, AtD, A);
 
-        // predictor step & length
         calcstep(A, A_trans, B, llt, s, y, r1, r2, r3, r4, dx, ds, dt, dy, tmp, rhs);
 
         alphap = -1.0;
@@ -166,12 +161,10 @@ std::tuple<VT, NT, bool>  max_inscribed_ball(MT const& A, VT const& b,
         alphap = -1.0 / alphap;
         alphad = -1.0 / alphad;
 
-        // determine mu
         ratio = (s + alphap * ds).dot((y + alphad * dy)) / gap;
         sigma = std::min(sigma0, ratio * ratio);
         mu = (sigma * gap) / NT(m);
 
-        // corrector and combined step & length
         mu_ds_dy.noalias() = e_m * mu - ds.cwiseProduct(dy);
         calcstep(A, A_trans, B, llt, s, y, o_m, o_n, 0.0, mu_ds_dy, dxc, dsc, dtc, dyc, tmp, rhs);
 
@@ -198,7 +191,6 @@ std::tuple<VT, NT, bool>  max_inscribed_ball(MT const& A, VT const& b,
         alphap = -1.0 / alphap;
         alphad = -1.0 / alphad;
 
-        // update iterates
         tau = std::max(tau0, 1.0 - gap / NT(m));
         alphap = std::min(1.0, tau * alphap);
         alphad = std::min(1.0, tau * alphad);
@@ -210,8 +202,10 @@ std::tuple<VT, NT, bool>  max_inscribed_ball(MT const& A, VT const& b,
         y += alphad * dy;
     }
 
-    std::tuple<VT, NT, bool> result = std::make_tuple(x, t, converge);
-    return result;
-}
+    if (!converge) {
+        t = NT(-1); 
+    }
 
-#endif // MAX_INSCRIBED_BALL_HPP
+    return std::make_tuple(x, t, converge);
+}
+#endif 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -122,6 +122,8 @@ GetLPSolve()
 include("../external/cmake-files/QD.cmake")
 GetQD()
 
+# add_subdirectory(test)
+
 # Code Coverage Configuration
 add_library(coverage_config INTERFACE)
 
@@ -383,7 +385,8 @@ add_test(NAME test_volumetric_center
 add_test(NAME test_vaidya_center
           COMMAND test_internal_points -tc=test_vaidya_center)
 
-          
+add_executable (test_max_inscribed_ball test_max_inscribed_ball.cpp $<TARGET_OBJECTS:test_main>)
+add_test(NAME test_max_inscribed_ball COMMAND test_max_inscribed_ball)
 
 set(ADDITIONAL_FLAGS "-march=native -DSIMD_LEN=0 -DTIME_KEEPING")
 

--- a/test/test_max_inscribed_ball.cpp
+++ b/test/test_max_inscribed_ball.cpp
@@ -1,0 +1,58 @@
+#include "doctest.h"
+
+#include <Eigen/Dense>
+#include <Eigen/Sparse>        
+#include <Eigen/SparseCholesky> 
+
+#include <cmath>
+
+#include "preprocess/max_inscribed_ball.hpp"
+
+TEST_CASE("max_inscribed_ball: unit box [-1,1]^n")
+{
+    using NT = double;
+    using MT = Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic>;
+    using VT = Eigen::Matrix<NT, Eigen::Dynamic, 1>;
+
+    const int n = 5;
+    const NT tol = 1e-8;
+
+    MT A(2 * n, n);
+    VT b(2 * n);
+
+    A.topRows(n) = MT::Identity(n, n);
+    A.bottomRows(n) = -MT::Identity(n, n);
+    b.setOnes();
+
+    auto [x, r, converged] = max_inscribed_ball(A, b, 10000, tol);
+
+    CHECK(converged);
+    CHECK(std::abs(r - 1.0) < 1e-6);
+    CHECK(x.norm() < 1e-6);
+    CHECK((A * x - b).maxCoeff() <= 1e-6);
+}
+
+TEST_CASE("max_inscribed_ball invalidates radius on non-convergence") {
+    using NT = double;
+    using MT = Eigen::MatrixXd;
+    using VT = Eigen::VectorXd;
+
+    // Define a very thin box in 2D
+    MT A(4, 2);
+    VT b(4);
+
+    A <<  1,  0,
+         -1,  0,
+          0,  1,
+          0, -1;
+
+    b << 1e-12, 1e-12, 1.0, 1.0;
+
+    unsigned int maxiter = 1;
+    NT tol = 1e-12;
+
+    auto [x, t, converge] = max_inscribed_ball(A, b, maxiter, tol);
+
+    REQUIRE_FALSE(converge);
+    REQUIRE(t < NT(0));   
+}


### PR DESCRIPTION
### Summary

Fixes a silent failure in `max_inscribed_ball` where the function could return a valid-looking center and radius even when the interior-point method failed to converge.

### Changes

- Explicitly invalidates the returned radius when `converge == false`
 
- Adds a numerical safeguard against division by near-zero slack values
 
- Documents the non-convergence failure contract

- Adds a regression test covering both successful and non-convergent cases

### Testing

- Added a regression test in `test_max_inscribed_ball.cpp`

- Verified locally with `./test_max_inscribed_ball`

Fixes #420