### PR TITLE
Optimise point.h 

### DIFF
--- a/include/cartesian_geom/point.h
+++ b/include/cartesian_geom/point.h
@@ -117,9 +117,10 @@ public:
         coeffs += p.getCoefficients();
     }
 
-    void operator+= (const Coeff& coeffs)
+    template<typename Derived>
+    void operator+= (const Eigen::MatrixBase<Derived>& other)
     {
-        this->coeffs += coeffs;
+        this->coeffs += other;
     }
 
     void operator-= (const point& p)
@@ -127,9 +128,10 @@ public:
         coeffs -= p.getCoefficients();
     }
 
-    void operator-= (const Coeff& coeffs)
+    template<typename Derived>
+    void operator-= (const Eigen::MatrixBase<Derived>& other)
     {
-        this->coeffs -= coeffs;
+        this->coeffs -= other;
     }
 
     void operator= (const Coeff& coeffs)
@@ -205,8 +207,7 @@ public:
     }
 
     FT squared_length() const {
-        FT lsq = length();
-        return lsq * lsq;
+        return coeffs.squaredNorm();
     }
 
     FT length() const {


### PR DESCRIPTION
# Optimize point class arithmetic

## Summary
This PR introduces significant performance optimizations to the core `point` class.

## Changes


###  Performance Optimizations
* **File:** `include/cartesian_geom/point.h`
*  1-> (`squared_length`):
    * Replaced `return length() * length()` with `return coeffs.squaredNorm()`.
    * **Benefit:** Eliminates an expensive square root instruction followed by a multiplication. This improves performance for distance-based checks and increases precision by avoiding floating-point errors.
*  2->(Overloading):
    * Added template overloads for `operator+=` and `operator-=` that accept `Eigen::MatrixBase<Derived>`.
    * **Benefit:** Enables lazy evaluation, improving performance by reducing memory load.



Adresses #434 
@vissarion please do look into this if there are any further changes to be made.