### PR TITLE
Optimised point

### DIFF
--- a/include/cartesian_geom/point.h
+++ b/include/cartesian_geom/point.h
@@ -112,14 +112,29 @@ public:
         return coeffs.sum();
     }
 
+    template<typename T>
+    void operator+= (const T& other)
+    {
+        if (other.rows() == 1 && other.cols() == d && d > 1) {
+            this->coeffs += other.transpose();
+        } else {
+            this->coeffs += other;
+        }
+    }
+    
     void operator+= (const point& p)
     {
         coeffs += p.getCoefficients();
     }
-
-    void operator+= (const Coeff& coeffs)
+    
+    template<typename T>
+    void operator-= (const T& other)
     {
-        this->coeffs += coeffs;
+        if (other.rows() == 1 && other.cols() == d && d > 1) {
+            this->coeffs -= other.transpose();
+        } else {
+            this->coeffs -= other;
+        }
     }
 
     void operator-= (const point& p)
@@ -127,10 +142,6 @@ public:
         coeffs -= p.getCoefficients();
     }
 
-    void operator-= (const Coeff& coeffs)
-    {
-        this->coeffs -= coeffs;
-    }
 
     void operator= (const Coeff& coeffs)
     {
@@ -205,8 +216,7 @@ public:
     }
 
     FT squared_length() const {
-        FT lsq = length();
-        return lsq * lsq;
+        return coeffs.squaredNorm();
     }
 
     FT length() const {


### PR DESCRIPTION
# Optimize point class arithmetic

## Summary
This PR introduces significant performance optimizations to the core `point` class.

## Changes


###  Performance Optimizations
* **File:** `include/cartesian_geom/point.h`
*  1-> (`squared_length`):
    * Replaced `return length() * length()` with `return coeffs.squaredNorm()`.
    * **Benefit:** Eliminates an expensive square root instruction followed by a multiplication. This improves performance for distance-based checks and increases precision by avoiding floating-point errors.
*  2->(Overloading):
    * Added template overloads for `operator+=` and `operator-=` that accept `Eigen::MatrixBase<Derived>`.
    * **Benefit:** Enables lazy evaluation, improving performance by reducing memory load.
    
  * From running the benchmarks, I have found there to be a speedup of about 10% ( 9~12), which i think is pretty significant for some of the much heavier computations that occur.



Adresses #434 
### Currently this runs into an issue with two tests:

1: volume_cg_hpolytope_simplex
2: test_max_ball_sparse


The reason for the issue is that the previous implementation required a temp variable to be created when doing a step like a+= b*c. Here, b*c used to be temporarily stored and then added to a. This causes two rounding operations: one during the b*c process and one during the addition. In a sense, this was less accurate.

The change I have made now only does one rounding operation, but due to this, the values don't match what the tests are expecting. 

@vissarion, how would you suggest moving forward with this?

