### PR TITLE
Fix numerical instability in Integral Collocation ODE Solver

### DIFF
--- a/include/ode_solvers/integral_collocation.hpp
+++ b/include/ode_solvers/integral_collocation.hpp
@@ -17,8 +17,13 @@
 #ifndef ODE_SOLVERS_INTEGRAL_COLLOCATION_HPP
 #define ODE_SOLVERS_INTEGRAL_COLLOCATION_HPP
 
+#include "basis.hpp"
+
+#ifndef DISABLE_NLP_ORACLES
 #include "nlp_oracles/nlp_hpolyoracles.hpp"
 #include "nlp_oracles/nlp_vpolyoracles.hpp"
+#endif
+
 #include "boost/numeric/ublas/vector.hpp"
 #include "boost/numeric/ublas/io.hpp"
 #include "boost/math/special_functions/chebyshev.hpp"
@@ -156,6 +161,8 @@ struct IntegralCollocationODESolver {
     NT err;
 
     do {
+      X_prev = X;
+
       for (unsigned int ord = 0; ord < order(); ord++) {
         for (unsigned int i = 0; i < xs.size(); i++) {
           for (unsigned int j = i * dim; j < (i + 1) * dim; j++) {
@@ -175,9 +182,7 @@ struct IntegralCollocationODESolver {
         }
       }
 
-      X = X0 + F_op * A_phi;
-
-      X_prev = X;
+      X = X0 + (F_op * A_phi) * (eta / 2.0);
 
       err = sqrt((X - X_prev).squaredNorm());
 
@@ -232,7 +237,7 @@ struct IntegralCollocationODESolver {
 
         // 5. Apply degree-doubling transformation
         // The transformation takes the n Chebyshev transform coefficients c[i]
-         // and creates a complex polynomial of order 2n with coefficients a[i]
+          // and creates a complex polynomial of order 2n with coefficients a[i]
         // such that a[n] = 2 * c[0], a[i] = c[i - n] for i > n and a[i] = c[n - i] for i < n
         // This polynomial h(z) is defined on the complex plane.
         // Its roots are related to the chebyshev transform as: z is a root of

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -428,3 +428,11 @@ TARGET_LINK_LIBRARIES(crhmc_sampling_test lp_solve ${IFOPT} ${IFOPT_IPOPT} ${PTH
 TARGET_LINK_LIBRARIES(order_polytope lp_solve coverage_config)
 TARGET_LINK_LIBRARIES(matrix_sampling_test lp_solve ${MKL_LINK} coverage_config)
 TARGET_LINK_LIBRARIES(test_internal_points lp_solve ${MKL_LINK} coverage_config)
+
+# This test requires FFTW3 and other dependencies skipped in minimal builds.
+if(NOT DISABLE_NLP_ORACLES)
+    add_executable(test_integral_collocation_stability test_integral_collocation_stability.cpp)
+
+    target_link_libraries(test_integral_collocation_stability lp_solve ${IFOPT} ${IFOPT_IPOPT} ${PTHREAD} ${GMP} ${MPSOLVE} ${FFTW3} ${MKL_LINK} QD_LIB coverage_config${Boost_LIBRARIES})
+    add_test(NAME test_integral_collocation_stability COMMAND test_integral_collocation_stability)
+endif()

--- a/test/test_integral_collocation_stability.cpp
+++ b/test/test_integral_collocation_stability.cpp
@@ -1,0 +1,72 @@
+// VolEsti (volume computation and sampling library)
+
+// Copyright (c) 2012-2020 Vissarion Fisikopoulos
+// Copyright (c) 2018-2020 Apostolos Chalkis
+// Copyright (c) 2026 Mohit Lakra
+
+// Licensed under GNU LGPL.3, see LICENCE file
+
+// Verifies the numerical stability and time-scaling correctness of the Integral Collocation
+// solver by checking for energy conservation in a Harmonic Oscillator (x'' = -x) simulation.
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE IntegralCollocationStability
+#include <boost/test/unit_test.hpp>
+#include <Eigen/Dense>
+#include "ode_solvers/integral_collocation.hpp"
+
+struct MockPoint {
+    std::vector<double> coords;
+    MockPoint(int dim = 2) : coords(dim, 0.0) {}
+    unsigned int dimension() const { return coords.size(); }
+    double operator[](int i) const { return coords[i]; }
+    void set_coord(int i, double val) { coords[i] = val; }
+};
+
+struct MockPolytope {
+    typedef Eigen::MatrixXd MT;
+    typedef Eigen::VectorXd VT;
+};
+
+struct HarmonicOscillator {
+    MockPoint operator()(unsigned int idx, const std::vector<MockPoint>& state, double t) {
+        double x = state[0][0];
+        double v = state[0][1];
+        MockPoint deriv(2);
+        deriv.set_coord(0, v);
+        deriv.set_coord(1, -x);
+        return deriv;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(test_integral_collocation_stability) {
+    double eta = 0.1; 
+    int steps = 100;
+    
+    MockPoint initial_pt(2);
+    initial_pt.set_coord(0, 0.0);
+    initial_pt.set_coord(1, 1.0);
+    std::vector<MockPoint> initial_state;
+    initial_state.push_back(initial_pt);
+    
+    std::vector<MockPolytope*> boundaries(1, nullptr);
+
+    IntegralCollocationODESolver<MockPoint, double, MockPolytope, HarmonicOscillator> 
+        solver(0.0, eta, initial_state, HarmonicOscillator(), boundaries, 10);
+
+    bool unstable = false;
+    
+    for (int i = 1; i <= steps; ++i) {
+        solver.step();
+        MockPoint current = solver.get_state(0);
+        
+        double radius = std::sqrt(current[0]*current[0] + current[1]*current[1]);
+        
+        if (radius > 1.5) {
+            unstable = true;
+            break;
+        }
+    }
+
+    BOOST_CHECK_MESSAGE(!unstable, "Instability detected! Energy grew uncontrollably.");
+}


### PR DESCRIPTION
This PR fixes the instability issues in IntegralCollocationODESolver (Issue #120).

After investigating the solver's behavior, I identified two distinct bugs that were causing the energy explosion:

1. The Math Fix (Missing Scaling) The core issue was a missing Jacobian scaling factor. The solver integrates on the normalized Chebyshev domain [−1,1] (width 2), but it wasn't scaling the result back to the physical time step [0,η]. This caused the solver to overshoot as if every time step was 2.0 units long, regardless of the actual step size.

Fix: I applied the correct (eta / 2.0) scaling factor to the integration step.

2. The Logic Fix (Broken Loop) I also found that the fixed-point iteration loop was "short-circuiting." The variable X_prev was being updated to match X immediately before the error check, meaning the calculated error was always 0.0. This forced the solver to exit after just one iteration, preventing true convergence.

Fix: I moved the X_prev update to the start of the loop, ensuring the error metric actually compares the current state against the previous one.

Verification
I verified these fixes locally using a Harmonic Oscillator test case (x '′ =−x).

Before: The system was unstable, with energy growing unboundedly (radius >1.5 within 100 steps).
<img width="956" height="133" alt="image" src="https://github.com/user-attachments/assets/6c53fd54-2f8f-4b89-b6a8-440a7a8a58cd" />

After: The solution is now stable and bounded (radius ≈1.0), confirming the physics are correct.
<img width="956" height="180" alt="Screenshot 2026-01-28 at 11 18 48 PM" src="https://github.com/user-attachments/assets/deba842c-b00d-4e09-8b14-bc896781b76d" />


Closes #120