### PR TITLE
Fix build crash on Clang by isolating lp_solve C flags

### DIFF
--- a/external/cmake-files/LPSolve.cmake
+++ b/external/cmake-files/LPSolve.cmake
@@ -71,4 +71,16 @@ endif(NOT APPLE)
   ${LP_SOLVE_DIR}/lp_utils.c
   ${LP_SOLVE_DIR}/lp_wlp.c)
 
+  # Force lp_solve to be compiled as pure C (not C++)
+  set_target_properties(lp_solve PROPERTIES
+  LINKER_LANGUAGE C
+  C_STANDARD 99
+  C_STANDARD_REQUIRED YES
+  )
+
+  # Remove accidental C++ flags
+  target_compile_options(lp_solve PRIVATE
+  $<$<COMPILE_LANGUAGE:C>:-std=c99>
+  )
+
 endfunction()


### PR DESCRIPTION
I ran into a build failure while trying to run some of the volume examples on my machine using Clang. It turns out that lp_solve (which is pure C) was accidentally trying to use the project-wide C++17 flags. Clang is pretty strict about this and throws an error because -std=c++17 isn't valid for C files.

I’ve updated LPSolve.cmake to make sure the lp_solve target is strictly treated as C.

What I changed:

Forced the LINKER_LANGUAGE to C for the lp_solve target.

Set the C_STANDARD to 99 so it doesn't try to inherit the C++ standard.

Added a generator expression to the compile options so that -std=c99 is only applied to C files. This effectively "shields" the dependency from any C++ flag leakage.

This should make the build process much smoother for anyone working on macOS or using newer versions of Clang.

Fixes: #440


Before : 
<img width="1904" height="292" alt="image" src="https://github.com/user-attachments/assets/17ce52f7-6d65-4d27-a0ae-caca74243429" />

After :
<img width="608" height="74" alt="Screenshot 2026-01-30 at 11 33 59 PM" src="https://github.com/user-attachments/assets/bacdbff6-9a6c-44f5-b880-e667583ccd38" />
