### PR TITLE
fix: correct broken links to credits and publications in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 
 ### ⭐ Credits
 
-* [Contributors and Package History](doc/credits.md)
-* [List of Publications](doc/publications.md)
+* [Contributors and Package History](docs/misc/credits.md)
+* [List of Publications](docs/misc/publications.md)
 
 ### © Copyright and Licensing
 


### PR DESCRIPTION
The doc/ directory does not exist; actual files are at docs/misc/credits.md and docs/misc/publications.md.
fixes #449
