### PR TITLE
geometry: standardize is_in() semantics and optimize H-Polytope boundary checks

### DIFF
--- a/include/convex_bodies/ball.h
+++ b/include/convex_bodies/ball.h
@@ -54,11 +54,10 @@ public:
         return c.dimension();
     }
 
-    int is_in(Point const& p) const
-    {
-        if (p.squared_length() <= R)
-            return -1;
-        else return 0;
+    int is_in(Point const& p, NT tol = NT(0)) const {
+        NT diff = (p - c).squared_length() - R;
+        if (diff > tol) return 1;
+        return (diff >= -tol) ? 0 : -1;
     }
 
     std::pair<NT,NT> line_intersect(Point const& r, Point const& v) const

--- a/include/convex_bodies/convex_body.h
+++ b/include/convex_bodies/convex_body.h
@@ -97,11 +97,14 @@ public:
     }
 
     // Check if point is in K
-    int is_in(Point const& p, NT tol=NT(0)) {
-        for (func g : gs) {
-            if (g(p) > NT(-tol)) return 0;
+    int is_in(Point const& p, NT tol=NT(0)) const {
+        NT max_val = -std::numeric_limits<NT>::max();
+        for (const auto& g : gs) {
+            NT val = g(p);
+            if (val > tol) return 1;
+            if (val > max_val) max_val = val;
         }
-        return -1;
+        return (max_val >= -tol) ? 0 : -1;
     }
 
 };

--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -324,19 +324,11 @@ public:
 
 
     //Check if Point p is in H-polytope P:= Ax<=b
-    int is_in(Point const& p, NT tol=NT(0)) const
-    {
-        int m = A.rows();
-        const NT* b_data = b.data();
-
-        for (int i = 0; i < m; i++) {
-            //Check if corresponding hyperplane is violated
-            if (*b_data - A.row(i) * p.getCoefficients() < NT(-tol))
-                return 0;
-
-            b_data++;
-        }
-        return -1;
+    int is_in(Point const& p, NT tol=NT(0)) const {
+        Eigen::Matrix<NT, Eigen::Dynamic, 1> res = A * p.getCoefficients() - b;
+        NT max_val = res.maxCoeff();
+        if (max_val > tol) return 1;
+        return (max_val >= -tol) ? 0 : -1;
     }
 
     // compute intersection point of ray starting from r and pointing to v


### PR DESCRIPTION
This PR standardizes the is_in return contract across Ball, ConvexBody, and HPolytope to return -1 for inside the body, 0 for the boundary within tolerance, and 1 for outside the body.
Key optimization includes replacing manual loops in HPolytope::is_in with Eigen's .maxCoeff() for faster violation detection in Ax <= b constraints. This ensures consistency across the library and prevents ambiguity in sampling algorithms.
These changes also implement a unified tolerance-based comparison to handle floating-point precision issues specifically at the geometric boundaries.