### PR TITLE
Fixed division bug in max_inscribed_ball causing test_max_ball failure

### DIFF
--- a/include/preprocess/max_inscribed_ball.hpp
+++ b/include/preprocess/max_inscribed_ball.hpp
@@ -32,7 +32,9 @@
 template <typename NT>
 inline NT safe_div(NT num, NT denom) {
     constexpr NT eps = NT(1e-12);
-    return num / std::max(denom, eps);
+    if (std::abs(denom) < eps)
+        denom = (denom >= 0 ? eps : -eps);
+    return num / denom;
 }
 
 template <typename MT, typename llt_type, typename VT, typename NT>

--- a/include/preprocess/max_inscribed_ball.hpp
+++ b/include/preprocess/max_inscribed_ball.hpp
@@ -28,6 +28,13 @@
             radius r
 */
 
+// numerical safeguard to prevent division by near-zero values
+template <typename NT>
+inline NT safe_div(NT num, NT denom) {
+    constexpr NT eps = NT(1e-12);
+    return num / std::max(denom, eps);
+}
+
 template <typename MT, typename llt_type, typename VT, typename NT>
 void calcstep(MT const& A, MT const& A_trans, MT const& B,
               llt_type const& llt, VT &s, VT &y, VT &r1,
@@ -38,7 +45,7 @@ void calcstep(MT const& A, MT const& A_trans, MT const& B,
     NT *vec_iter1 = tmp.data(), *vec_iter2 = y.data(), *vec_iter3 = s.data(),
        *vec_iter4 = r1.data(), *vec_iter5 = r4.data();
     for (int i = 0; i < m; ++i) {
-        *vec_iter1 = ((*vec_iter4) / (*vec_iter2) - (*vec_iter5)) / (*vec_iter3);
+        *vec_iter1 = (safe_div(*vec_iter4, *vec_iter2) - safe_div(*vec_iter5, *vec_iter3));
         vec_iter1++; vec_iter2++; vec_iter3++; vec_iter4++; vec_iter5++;
     }
 
@@ -54,7 +61,7 @@ void calcstep(MT const& A, MT const& A_trans, MT const& B,
     vec_iter4 = ds.data(); vec_iter5 = s.data();
 
     for (int i = 0; i < m; ++i) {
-        *vec_iter1 = ((*vec_iter2) - (*vec_iter3) * (*vec_iter4)) / (*vec_iter5);
+        *vec_iter1 = safe_div((*vec_iter2) - (*vec_iter3) * (*vec_iter4), *vec_iter5);
         vec_iter1++; vec_iter2++; vec_iter3++; vec_iter4++; vec_iter5++;
     }
 }
@@ -156,8 +163,8 @@ std::tuple<VT, NT, bool>  max_inscribed_ball(MT const& A, VT const& b,
         vec_iter4 = y.data();
 
         for (int j = 0; j < m; ++j) {
-            alphap = std::min(alphap, (*vec_iter1) / (*vec_iter2));
-            alphad = std::min(alphad, (*vec_iter3) / (*vec_iter4));
+            alphap = std::min(alphap, safe_div(*vec_iter1, *vec_iter2));
+            alphad = std::min(alphad, safe_div(*vec_iter3, *vec_iter4));
             vec_iter1++;
             vec_iter2++;
             vec_iter3++;
@@ -188,8 +195,8 @@ std::tuple<VT, NT, bool>  max_inscribed_ball(MT const& A, VT const& b,
         vec_iter4 = y.data();
 
         for (int j = 0; j < m; ++j) {
-            alphap = std::min(alphap, (*vec_iter1) / (*vec_iter2));
-            alphad = std::min(alphad, (*vec_iter3) / (*vec_iter4));
+            alphap = std::min(alphap, safe_div(*vec_iter1, *vec_iter2));
+            alphad = std::min(alphad, safe_div(*vec_iter3, *vec_iter4));
             vec_iter1++;
             vec_iter2++;
             vec_iter3++;

--- a/include/preprocess/max_inscribed_ball.hpp
+++ b/include/preprocess/max_inscribed_ball.hpp
@@ -45,7 +45,7 @@ void calcstep(MT const& A, MT const& A_trans, MT const& B,
     NT *vec_iter1 = tmp.data(), *vec_iter2 = y.data(), *vec_iter3 = s.data(),
        *vec_iter4 = r1.data(), *vec_iter5 = r4.data();
     for (int i = 0; i < m; ++i) {
-        *vec_iter1 = (safe_div(*vec_iter4, *vec_iter2) - safe_div(*vec_iter5, *vec_iter3));
+        *vec_iter1 = safe_div(safe_div(*vec_iter4, *vec_iter2) - (*vec_iter5), *vec_iter3);
         vec_iter1++; vec_iter2++; vec_iter3++; vec_iter4++; vec_iter5++;
     }
 


### PR DESCRIPTION
Fixes - #453 

This PR resolves the numerical instability reported in #453 by introducing a safeguarded division helper to prevent divisions by extremely small values during the interior-point iterations of max_inscribed_ball.

**Implementation**
Added a helper function:

```
template <typename NT>
inline NT safe_div(NT num, NT denom) {
    constexpr NT eps = NT(1e-12);
    if (std::abs(denom) < eps)
        denom = (denom >= 0 ? eps : -eps);
    return num / denom;
}
```
The unstable division was replaced with guarded divisions using safe_div, ensuring that denominators do not approach zero.

**Testing**
`test_max_ball` now passes.

<img width="1308" height="213" alt="volesti-bug-solved" src="https://github.com/user-attachments/assets/4d52b759-162a-4015-8e73-25350c4bab6d" />