### PR TITLE
Fix: initialize facet to -1 in line_positive_intersect to prevent undefined behavior

### DIFF
--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -388,7 +388,7 @@ public:
         NT min_plus  = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
         VT sum_nom;
-        int m = num_of_hyperplanes(), facet;
+        int m = num_of_hyperplanes(), facet = -1;
 
         Ar.noalias() = A * r.getCoefficients();
         sum_nom = b - Ar;
@@ -432,7 +432,7 @@ public:
         NT mult;
         //unsigned int i, j;
         unsigned int j;
-        int m = num_of_hyperplanes(), facet;
+        int m = num_of_hyperplanes(), facet = -1;
 
         Ar.noalias() += lambda_prev*Av;
         sum_nom = b - Ar;
@@ -546,7 +546,7 @@ public:
         NT lamda = 0;
         NT inner_prev = params.inner_vi_ak;
         VT sum_nom;
-        int m = num_of_hyperplanes(), facet;
+        int m = num_of_hyperplanes(), facet = -1;
         int skip = params.facet_prev;
 
         Ar.noalias() += lambda_prev*Av;
@@ -649,7 +649,7 @@ public:
 
         NT lamda = 0;
         VT sum_nom;
-        int m = num_of_hyperplanes(), facet;
+        int m = num_of_hyperplanes(), facet = -1;
         int skip = params.facet_prev;
 
         Ar.noalias() += lambda_prev*Av;

--- a/include/random_walks/gaussian_ball_walk.hpp
+++ b/include/random_walks/gaussian_ball_walk.hpp
@@ -53,7 +53,7 @@ struct Walk
     }
 
     Walk (Polytope& P, Point const& p, NT const& a,
-          RandomNumberGenerator &rng)
+          RandomNumberGenerator &rng) : _a_i(a)
     {
         _delta = compute_delta(P, a);
     }
@@ -62,10 +62,19 @@ struct Walk
           Point const& p,
           NT const& a,
           RandomNumberGenerator &rng,
-          parameters const& params)
+          parameters const& params) : _a_i(a)
     {
         _delta = params.set_delta ? params.m_L
                                   : compute_delta(P, a);
+    }
+
+    template<typename BallPolytope>
+    inline void apply(BallPolytope const& P,
+                      Point &p,
+                      unsigned int const& walk_length,
+                      RandomNumberGenerator& rng)
+    {
+        apply(P, p, _a_i, walk_length, rng);
     }
 
     template<typename BallPolytope>
@@ -100,6 +109,7 @@ struct Walk
 
 private :
     NT _delta;
+    NT _a_i;
 };
 
 };

--- a/include/random_walks/gaussian_hamiltonian_monte_carlo_exact_walk.hpp
+++ b/include/random_walks/gaussian_hamiltonian_monte_carlo_exact_walk.hpp
@@ -9,6 +9,7 @@
 #define RANDOM_WALKS_GAUSSIAN_EXACT_HMC_WALK_HPP
 
 #include "sampling/sphere.hpp"
+#include "random_walks/compute_diameter.hpp"
 
 
 
@@ -62,7 +63,7 @@ struct Walk
                 ::template compute<NT>(P);
         _omega = std::sqrt(NT(2) * a_i);
         _rho = 100 * P.dimension(); // upper bound for the number of reflections (experimental)
-        initialize(P, p, a_i, rng);
+        initialize(P, p, rng);
     }
 
     template <typename GenericPolytope>
@@ -74,7 +75,7 @@ struct Walk
                             ::template compute<NT>(P);
         _omega = std::sqrt(NT(2) * a_i);
         _rho = 100 * P.dimension(); // upper bound for the number of reflections (experimental)
-        initialize(P, p, a_i, rng);
+        initialize(P, p, rng);
     }
 
     template
@@ -84,6 +85,18 @@ struct Walk
     inline void apply(GenericPolytope const& P,
                       Point& p,
                       NT const& a_i,
+                      unsigned int const& walk_length,
+                      RandomNumberGenerator &rng)
+    {
+        apply(P, p, walk_length, rng);
+    }
+
+    template
+    <
+        typename GenericPolytope
+    >
+    inline void apply(GenericPolytope const& P,
+                      Point& p,
                       unsigned int const& walk_length,
                       RandomNumberGenerator &rng)
     {
@@ -198,7 +211,6 @@ private :
     >
     inline void initialize(GenericPolytope const& P,
                            Point const& p,
-                           NT const& a_i,
                            RandomNumberGenerator &rng)
     {
         unsigned int n = P.dimension();

--- a/include/random_walks/gaussian_rdhr_walk.hpp
+++ b/include/random_walks/gaussian_rdhr_walk.hpp
@@ -80,12 +80,24 @@ struct Walk
     typedef typename Polytope::PointType Point;
     typedef typename Point::FT NT;
 
-    Walk(Polytope&, Point const&, NT const&, RandomNumberGenerator&)
+    Walk(Polytope&, Point const&, NT const& a, RandomNumberGenerator&) : _a_i(a)
     {}
 
-    Walk(Polytope&, Point const&, NT const&, RandomNumberGenerator&,
-         parameters&)
+    Walk(Polytope&, Point const&, NT const& a, RandomNumberGenerator&,
+         parameters&) : _a_i(a)
     {}
+
+    template
+    <
+        typename BallPolytope
+    >
+    inline void apply(BallPolytope const& P,
+                      Point &p,
+                      unsigned int const& walk_length,
+                      RandomNumberGenerator &rng)
+    {
+        apply(P, p, _a_i, walk_length, rng);
+    }
 
     template
     <
@@ -110,6 +122,9 @@ struct Walk
             chord_random_point_generator_exp(lower, upper, a_i, p, rng);
         }
     }
+
+private:
+    NT _a_i;
 };
 
 };

--- a/include/sampling/random_point_generators.hpp
+++ b/include/sampling/random_point_generators.hpp
@@ -155,7 +155,7 @@ struct GaussianRandomPointGenerator
         Walk walk(P, p, a_i, rng);
         for (unsigned int i=0; i<rnum; ++i)
         {
-            walk.apply(P, p, a_i, walk_length, rng);
+            walk.apply(P, p, walk_length, rng);
             policy.apply(randPoints, p);
         }
     }
@@ -184,7 +184,7 @@ struct GaussianRandomPointGenerator
 
         for (unsigned int i=0; i<rnum; ++i)
         {
-            walk.apply(P, p, a_i, walk_length, rng);
+            walk.apply(P, p, walk_length, rng);
             policy.apply(randPoints, p);
         }
     }


### PR DESCRIPTION
hi @vissarion sir

In `HPolytope::line_positive_intersect` (the `update_parameters` overload, ~line 520 of `hpolytope.h`), the variable `facet` is declared but never initialized:

```cpp
int m = num_of_hyperplanes(), facet;  // uninitialized
```

this by default takes garabge value, so it leads to error. 
i have set this value to -1.

i have also attached all the proofs below.


<img width="998" height="876" alt="Image" src="https://github.com/user-attachments/assets/ac4d7357-7ad1-4e4d-bdbd-db84ccc41c26" />

![Image](https://github.com/user-attachments/assets/36617db0-c6d8-4d5e-a729-804ecff0d707)
![Image](https://github.com/user-attachments/assets/466cdb60-2832-4362-8aee-2f510949c2a3)
![Image](https://github.com/user-attachments/assets/4a082b6e-d248-485b-b40a-dec5705ab95d)
