### PR TITLE
docs: fix stale repository links and clarify build path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,6 @@ Other helpful links:
 - https://opensource.com/article/18/1/step-step-guide-git
 
 ## Testing the development branch of volesti (get the tools ready)
-
-> **⚠️ Important Note on Building:**
-> The root directory of this repository follows an R package structure and does not contain a `CMakeLists.txt` file. To compile the C++ source code, you **must** navigate into the `test/` directory (or `examples/`) where the build system is defined. Running `cmake` from the root will result in an error.
-
 Clone the repository,
 
     git clone git@github.com:GeomScale/volesti.git volesti

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ Other helpful links:
 - https://opensource.com/article/18/1/step-step-guide-git
 
 ## Testing the development branch of volesti (get the tools ready)
+
 Clone the repository,
 
     git clone git@github.com:GeomScale/volesti.git volesti

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,12 @@ Other helpful links:
 
 ## Testing the development branch of volesti (get the tools ready)
 
+> **⚠️ Important Note on Building:**
+> The root directory of this repository follows an R package structure and does not contain a `CMakeLists.txt` file. To compile the C++ source code, you **must** navigate into the `test/` directory (or `examples/`) where the build system is defined. Running `cmake` from the root will result in an error.
+
 Clone the repository,
 
-    git clone git@github.com:GeomScale/volume_approximation.git volesti
+    git clone git@github.com:GeomScale/volesti.git volesti
     cd volesti
     git branch -vv
 
@@ -74,7 +77,7 @@ repository.
 ![fork](https://user-images.githubusercontent.com/3660366/72348562-57fe9680-36e3-11ea-9746-385ff61c752a.png)
 
 1. login on `GitHub`
-2. go to [volesti repository](https://github.com/GeomScale/volume_approximation)
+2. go to [volesti repository](https://github.com/GeomScale/volesti)
 3. click the 'Fork' button
 4. choose your profile
 5. wait
@@ -90,7 +93,7 @@ Go out of `volesti` directory
 
 clone your repository and checkout develop branch
 
-    git clone git@github.com:vissarion/volume_approximation.git volesti_fork
+    git clone git@github.com:vissarion/volesti.git volesti_fork
     cd volesti_fork
     git remote add upstream git@github.com:GeomScale/volesti.git
     git fetch upstream
@@ -217,4 +220,4 @@ Those changes will automatically be a part of the same pull request. This proced
 is ready for merging.
 
 If you're curious how it looks like you may see one of the open or closed
-[pull requests](https://github.com/GeomScale/volume_approximation/pulls).
+[pull requests](https://github.com/GeomScale/volesti/pulls).


### PR DESCRIPTION
Updated all repository links from the deprecated volume_approximation naming to the current volesti naming to ensure consistency and avoid redirects.

Added a critical build note to inform new contributors that the CMakeLists.txt is located within the /test or /examples directories, not the root. This addresses common setup errors caused by the repository's R package structure.