### PR TITLE
perf: remove unnecessary matrix transpose copy in MMCS sampling (Fixes #413)

### DIFF
--- a/include/sampling/mmcs.hpp
+++ b/include/sampling/mmcs.hpp
@@ -230,16 +230,18 @@ void mmcs(Polytope const& Pin,
         std::cout << "phase " << phase << ": number of correlated samples = " << total_samples << ", effective sample size = " << Neff_sampled;
         total_neff += Neff_sampled;
         Neff_sampled = 0;
-
-        MT Samples = TotalRandPoints.transpose(); //do not copy TODO!
+        
+        // Optimized: avoid transpose copy by working directly with rows
+        S.conservativeResize(P.dimension(), total_number_of_samples_in_P0 + total_samples);
         for (int i = 0; i < total_samples; i++)
         {
-            Samples.col(i) = T * Samples.col(i) + T_shift;
+            // Transform each sample: T * sample + T_shift, then store as column in S
+            S.col(total_number_of_samples_in_P0 + i).noalias() =
+                T * TotalRandPoints.row(i).transpose() + T_shift;
         }
 
-        S.conservativeResize(P.dimension(), total_number_of_samples_in_P0 + total_samples);
-        S.block(0, total_number_of_samples_in_P0, P.dimension(), total_samples) = Samples.block(0, 0, P.dimension(), total_samples);
         total_number_of_samples_in_P0 += total_samples;
+
         if (!complete)
         {
             if (request_rounding && !rounding_completed)


### PR DESCRIPTION
Hello again! 

While reviewing the codebase, I noticed that Issue #413 regarding the memory overhead in MMCS sampling was still open after the previous attempt (PR #431) was abandoned and deleted by its author.

**Changes made:**
I have implemented the optimal solution to eliminate the intermediate `Samples` matrix creation:
* Removed the expensive `TotalRandPoints.transpose()` copy operation.
* Modified the transformation loop to work directly with `TotalRandPoints.row(i)`.
* Utilized Eigen's `.noalias()` to evaluate the matrix-vector multiplication directly into the `S` matrix.

This prevents Eigen from creating temporary variables, significantly reducing memory bandwidth and avoiding the $O(n \times d)$ transpose overhead during large sampling scenarios.

Fixes #413