### PR TITLE
fix: resolve numerical failures and premature caching in ComputeInnerBall

### DIFF
--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -3,37 +3,35 @@
 // Copyright (c) 2012-2020 Vissarion Fisikopoulos
 // Copyright (c) 2018 Apostolos Chalkis
 
-//Contributed and/or modified by Apostolos Chalkis, as part of Google Summer of Code 2018-19 programs.
-//Contributed and/or modified by Repouskos Panagiotis, as part of Google Summer of Code 2019 program.
-//Contributed and/or modified by Alexandros Manochis, as part of Google Summer of Code 2020 program.
-//Contributed and/or modified by Luca Perju, as part of Google Summer of Code 2024 program.
-//Contributed and/or modified by Iva Janković, as part of Google Summer of Code 2025 program.
-//Contributed and/or modified by Vladimir Necula, as part of Google Summer of Code 2025 program.
+// Contributed and/or modified by Apostolos Chalkis, as part of Google Summer of
+// Code 2018-19 programs. Contributed and/or modified by Repouskos Panagiotis,
+// as part of Google Summer of Code 2019 program. Contributed and/or modified by
+// Alexandros Manochis, as part of Google Summer of Code 2020 program.
+// Contributed and/or modified by Luca Perju, as part of Google Summer of Code
+// 2024 program. Contributed and/or modified by Iva Janković, as part of Google
+// Summer of Code 2025 program. Contributed and/or modified by Vladimir Necula,
+// as part of Google Summer of Code 2025 program.
 
 // Licensed under GNU LGPL.3, see LICENCE file
 
 #ifndef HPOLYTOPE_H
 #define HPOLYTOPE_H
 
-#include <limits>
-#include <iostream>
-#include <Eigen/Eigen>
 #include "preprocess/max_inscribed_ball.hpp"
 #include "root_finders/quadratic_polynomial_solvers.hpp"
+#include <Eigen/Eigen>
+#include <iostream>
+#include <limits>
 #ifndef DISABLE_LPSOLVE
-    #include "lp_oracles/solve_lp.h"
+#include "lp_oracles/solve_lp.h"
 #endif
 
-
-
 // check if an Eigen vector contains NaN or infinite values
-template <typename VT>
-bool is_inner_point_nan_inf(VT const& p)
-{
+template <typename VT> bool is_inner_point_nan_inf(VT const &p) {
     typedef Eigen::Array<bool, Eigen::Dynamic, 1> VTint;
     VTint a = p.array().isNaN();
     for (int i = 0; i < p.rows(); i++) {
-        if (a(i) || std::isinf(p(i))){
+        if (a(i) || std::isinf(p(i))) {
             return true;
         }
     }
@@ -43,54 +41,47 @@ bool is_inner_point_nan_inf(VT const& p)
 /// This class describes a polytope in H-representation or an H-polytope
 /// i.e. a polytope defined by a set of linear inequalities
 /// \tparam Point Point type
-template 
-<
-    typename Point, 
-    typename MT_type = Eigen::Matrix<typename Point::FT, Eigen::Dynamic, Eigen::Dynamic>
->
+template <typename Point,
+          typename MT_type =
+              Eigen::Matrix<typename Point::FT, Eigen::Dynamic, Eigen::Dynamic>>
 class HPolytope {
-public:
-    typedef Point                                             PointType;
-    typedef typename Point::FT                                NT;
-    typedef typename std::vector<NT>::iterator                viterator;
-    typedef MT_type                                           MT;
-    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT;
+  public:
+    typedef Point PointType;
+    typedef typename Point::FT NT;
+    typedef typename std::vector<NT>::iterator viterator;
+    typedef MT_type MT;
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
     typedef Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> DenseMT;
-    typedef Eigen::SparseMatrix<NT, Eigen::RowMajor>         SparseRowMT;
+    typedef Eigen::SparseMatrix<NT, Eigen::RowMajor> SparseRowMT;
 
-private:
-    unsigned int         _d; //dimension
-    MT                   A; //matrix A
-    VT                   b; // vector b, s.t.: Ax<=b
+  private:
+    unsigned int _d; // dimension
+    MT A;            // matrix A
+    VT b;            // vector b, s.t.: Ax<=b
     std::pair<Point, NT> _inner_ball;
-    bool                 normalized = false; // true if the polytope is normalized
-    bool                 has_ball = false;
+    bool normalized = false; // true if the polytope is normalized
+    bool has_ball = false;
 
-public:
-    //TODO: the default implementation of the Big3 should be ok. Recheck.
+  public:
+    // TODO: the default implementation of the Big3 should be ok. Recheck.
     HPolytope() {}
 
-    HPolytope(unsigned d_, MT const& A_, VT const& b_) :
-        _d{d_}, A{A_}, b{b_}
-    {
-    }
+    HPolytope(unsigned d_, MT const &A_, VT const &b_) : _d{d_}, A{A_}, b{b_} {}
 
-    template<typename T = DenseMT>
-    HPolytope(unsigned d_, DenseMT const& A_, VT const& b_, typename std::enable_if<!std::is_same<MT, T>::value, T>::type* = 0) :
-        _d{d_}, A{A_.sparseView()}, b{b_}
-    {
-    }
+    template <typename T = DenseMT>
+    HPolytope(
+        unsigned d_, DenseMT const &A_, VT const &b_,
+        typename std::enable_if<!std::is_same<MT, T>::value, T>::type * = 0)
+        : _d{d_}, A{A_.sparseView()}, b{b_} {}
 
     // Copy constructor
-    HPolytope(HPolytope<Point, MT> const& p) :
-            _d{p._d}, A{p.A}, b{p.b}, _inner_ball{p._inner_ball}, normalized{p.normalized}, has_ball{p.has_ball}
-    {
-    }
+    HPolytope(HPolytope<Point, MT> const &p)
+        : _d{p._d}, A{p.A}, b{p.b}, _inner_ball{p._inner_ball},
+          normalized{p.normalized}, has_ball{p.has_ball} {}
 
-    //define matrix A and vector b, s.t. Ax<=b,
-    // from a matrix that contains both A and b, i.e., [A | b ]
-    HPolytope(std::vector<std::vector<NT>> const& Pin)
-    {
+    // define matrix A and vector b, s.t. Ax<=b,
+    //  from a matrix that contains both A and b, i.e., [A | b ]
+    HPolytope(std::vector<std::vector<NT>> const &Pin) {
         _d = Pin[0][1] - 1;
         A.resize(Pin.size() - 1, _d);
         b.resize(Pin.size() - 1);
@@ -104,33 +95,30 @@ public:
         //_inner_ball = ComputeChebychevBall<NT, Point>(A, b);
     }
 
+    std::pair<Point, NT> InnerBall() const { return _inner_ball; }
 
-    std::pair<Point, NT> InnerBall() const
-    {
-        return _inner_ball;
-    }
-
-    void set_InnerBall(std::pair<Point,NT> const& innerball) //const
+    void set_InnerBall(std::pair<Point, NT> const &innerball) // const
     {
         _inner_ball = innerball;
         has_ball = true;
     }
 
-    void set_interior_point(Point const& r)
-    {
+    void set_interior_point(Point const &r) {
         _inner_ball.first = r;
-        if(!is_in(r)) {
-            std::cerr << "point outside of polytope was set as interior point" << std::endl;
+        if (!is_in(r)) {
+            std::cerr << "point outside of polytope was set as interior point"
+                      << std::endl;
             has_ball = false;
             return;
         }
-        if(is_normalized()) {
+        if (is_normalized()) {
             _inner_ball.second = (b - A * r.getCoefficients()).minCoeff();
         } else {
             _inner_ball.second = std::numeric_limits<NT>::max();
-            for(int i = 0; i < num_of_hyperplanes(); ++i) {
-                NT dist = (b(i) - A.row(i).dot(r.getCoefficients()) ) / A.row(i).norm();
-                if(dist < _inner_ball.second) {
+            for (int i = 0; i < num_of_hyperplanes(); ++i) {
+                NT dist = (b(i) - A.row(i).dot(r.getCoefficients())) /
+                          A.row(i).norm();
+                if (dist < _inner_ball.second) {
                     _inner_ball.second = dist;
                 }
             }
@@ -138,35 +126,42 @@ public:
         has_ball = true;
     }
 
-    //Compute Chebyshev ball of H-polytope P:= Ax<=b
-    //First try using max_inscribed_ball
-    //Use LpSolve library if it fails
-    std::pair<Point, NT> ComputeInnerBall()
-    {
+    // Compute Chebyshev ball of H-polytope P:= Ax<=b
+    // First try using max_inscribed_ball
+    // Use LpSolve library if it fails
+    std::pair<Point, NT> ComputeInnerBall() {
         normalize();
         if (!has_ball) {
             NT const tol = 1e-08;
-            std::tuple<VT, NT, bool> inner_ball = max_inscribed_ball(A, b, 5000, tol);
+            std::tuple<VT, NT, bool> inner_ball =
+                max_inscribed_ball(A, b, 5000, tol);
 
             // check if the solution is feasible
-            if (is_in(Point(std::get<0>(inner_ball))) == 0 || std::get<1>(inner_ball) < tol/2.0 ||
-                std::isnan(std::get<1>(inner_ball)) || std::isinf(std::get<1>(inner_ball)) ||
+            if (is_in(Point(std::get<0>(inner_ball))) == 0 ||
+                std::get<1>(inner_ball) < tol / 2.0 ||
+                std::isnan(std::get<1>(inner_ball)) ||
+                std::isinf(std::get<1>(inner_ball)) ||
                 is_inner_point_nan_inf(std::get<0>(inner_ball))) {
 
-                std::cerr << "Failed to compute max inscribed ball, trying to use lpsolve" << std::endl;
-                #ifndef DISABLE_LPSOLVE
-                    auto lp_result = ComputeChebychevBall<NT, Point>(A, b);
-                    if (lp_result.second >= tol/2.0) {
-                        _inner_ball = lp_result;
-                        has_ball = true;
-                    } else {
-                        std::cerr << "lpsolve also failed; polytope may not be full-dimensional" << std::endl;
-                        return {Point(_d), NT(-1)};
-                    }
-                #else
-                    std::cerr << "lpsolve is disabled, unable to compute inner ball" << std::endl;
+                std::cerr << "Failed to compute max inscribed ball, trying to "
+                             "use lpsolve"
+                          << std::endl;
+#ifndef DISABLE_LPSOLVE
+                auto lp_result = ComputeChebychevBall<NT, Point>(A, b);
+                if (lp_result.second >= tol / 2.0) {
+                    _inner_ball = lp_result;
+                    has_ball = true;
+                } else {
+                    std::cerr << "lpsolve also failed; polytope may not be "
+                                 "full-dimensional"
+                              << std::endl;
                     return {Point(_d), NT(-1)};
-                #endif
+                }
+#else
+                std::cerr << "lpsolve is disabled, unable to compute inner ball"
+                          << std::endl;
+                return {Point(_d), NT(-1)};
+#endif
             } else {
                 _inner_ball.first = Point(std::get<0>(inner_ball));
                 _inner_ball.second = std::get<1>(inner_ball);
@@ -177,80 +172,45 @@ public:
     }
 
     // return dimension
-    unsigned int dimension() const
-    {
-        return _d;
-    }
-
+    unsigned int dimension() const { return _d; }
 
     // return the number of facets
-    int num_of_hyperplanes() const
-    {
-        return A.rows();
-    }
+    int num_of_hyperplanes() const { return A.rows(); }
 
-    int num_of_generators() const
-    {
-        return 0;
-    }
-
+    int num_of_generators() const { return 0; }
 
     // return the matrix A
-    MT get_mat() const
-    {
-        return A;
-    }
+    MT get_mat() const { return A; }
 
-
-    MT get_AA() const {
-        return A * A.transpose();
-    }
+    MT get_AA() const { return A * A.transpose(); }
 
     // return the vector b
-    VT get_vec() const
-    {
-        return b;
-    }
+    VT get_vec() const { return b; }
 
-    VT get_row(int facet_index) const 
-    {
+    VT get_row(int facet_index) const {
         if (facet_index < 0 || facet_index >= A.rows())
             throw std::out_of_range("Facet index out of range!");
         return A.row(facet_index);
     }
-    
-    bool is_normalized ()
-    {
-        return normalized;
-    }
 
+    bool is_normalized() { return normalized; }
 
     // change the matrix A
-    void set_mat(MT const& A2)
-    {
+    void set_mat(MT const &A2) {
         A = A2;
         normalized = false;
         has_ball = false;
     }
 
-
     // change the vector b
-    void set_vec(VT const& b2)
-    {
+    void set_vec(VT const &b2) {
         b = b2;
         has_ball = false;
     }
 
-    Point get_mean_of_vertices() const
-    {
-        return Point(_d);
-    }
+    Point get_mean_of_vertices() const { return Point(_d); }
 
-    NT get_max_vert_norm() const
-    {
-        return 0.0;
-    }
-
+    NT get_max_vert_norm() const { return 0.0; }
 
     // print polytope in input format
     void print() {
@@ -262,7 +222,6 @@ public:
             std::cout << "<= " << b(i) << std::endl;
         }
     }
-
 
     // Compute the reduced row echelon form
     // used to transofm {Ax=b,x>=0} to {A'x'<=b'}
@@ -288,8 +247,8 @@ public:
         }
         for(typename stdMatrix::iterator mit=_A.begin(); mit<_A.end(); ++mit){
             int j =0;
-            for(typename stdCoeffs::iterator lit=mit->begin(); lit<mit->end() ; ){
-                if(zeros[j]==_A.size()-1 && ones[j]==1)
+            for(typename stdCoeffs::iterator lit=mit->begin(); lit<mit->end() ;
+    ){ if(zeros[j]==_A.size()-1 && ones[j]==1)
                     (*mit).erase(lit);
                 else{ //reverse sign in all but the first column
                     if(lit!=mit->end()-1) *lit = (-1)*(*lit);
@@ -307,8 +266,8 @@ public:
         //delete zero rows
         for (typename stdMatrix::iterator mit=_A.begin(); mit<_A.end(); ){
             int zero=0;
-            for(typename stdCoeffs::iterator lit=mit->begin(); lit<mit->end() ; ++lit){
-                if(*lit==double(0)) ++zero;
+            for(typename stdCoeffs::iterator lit=mit->begin(); lit<mit->end() ;
+    ++lit){ if(*lit==double(0)) ++zero;
             }
             if(zero==(*mit).size())
                 _A.erase(mit);
@@ -328,15 +287,13 @@ public:
         return 1;
     }*/
 
-
-    //Check if Point p is in H-polytope P:= Ax<=b
-    int is_in(Point const& p, NT tol=NT(0)) const
-    {
+    // Check if Point p is in H-polytope P:= Ax<=b
+    int is_in(Point const &p, NT tol = NT(0)) const {
         int m = A.rows();
-        const NT* b_data = b.data();
+        const NT *b_data = b.data();
 
         for (int i = 0; i < m; i++) {
-            //Check if corresponding hyperplane is violated
+            // Check if corresponding hyperplane is violated
             if (*b_data - A.row(i) * p.getCoefficients() < NT(-tol))
                 return 0;
 
@@ -347,33 +304,33 @@ public:
 
     // compute intersection point of ray starting from r and pointing to v
     // with polytope discribed by A and b
-    std::pair<NT,NT> line_intersect(Point const& r, Point const& v) const
-    {
+    std::pair<NT, NT> line_intersect(Point const &r, Point const &v) const {
 
         NT lamda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
         VT sum_nom, sum_denom;
-        //unsigned int i, j;
+        // unsigned int i, j;
         unsigned int j;
         int m = num_of_hyperplanes();
-
 
         sum_nom.noalias() = b - A * r.getCoefficients();
         sum_denom.noalias() = A * v.getCoefficients();
 
-        NT* sum_nom_data = sum_nom.data();
-        NT* sum_denom_data = sum_denom.data();
+        NT *sum_nom_data = sum_nom.data();
+        NT *sum_denom_data = sum_denom.data();
 
         for (int i = 0; i < m; i++) {
 
             if (*sum_denom_data == NT(0)) {
-                //std::cout<<"div0"<<std::endl;
+                // std::cout<<"div0"<<std::endl;
                 ;
             } else {
                 lamda = *sum_nom_data / *sum_denom_data;
-                if (lamda < min_plus && lamda > 0) min_plus = lamda;
-                if (lamda > max_minus && lamda < 0) max_minus = lamda;
+                if (lamda < min_plus && lamda > 0)
+                    min_plus = lamda;
+                if (lamda > max_minus && lamda < 0)
+                    max_minus = lamda;
             }
 
             sum_nom_data++;
@@ -384,146 +341,134 @@ public:
 
     // compute intersection points of a ray starting from r and pointing to v
     // with polytope discribed by A and b
-    std::pair<NT,NT> line_intersect(Point const& r,
-                                    Point const& v,
-                                    VT& Ar,
-                                    VT& Av,
-                                    bool pos = false) const
-    {
+    std::pair<NT, NT> line_intersect(Point const &r, Point const &v, VT &Ar,
+                                     VT &Av, bool pos = false) const {
         NT lamda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
         VT sum_nom;
         int m = num_of_hyperplanes(), facet;
 
         Ar.noalias() = A * r.getCoefficients();
         sum_nom = b - Ar;
-        Av.noalias() = A * v.getCoefficients();;
+        Av.noalias() = A * v.getCoefficients();
+        ;
 
-
-        NT* Av_data = Av.data();
-        NT* sum_nom_data = sum_nom.data();
+        NT *Av_data = Av.data();
+        NT *sum_nom_data = sum_nom.data();
 
         for (int i = 0; i < m; i++) {
             if (*Av_data == NT(0)) {
-                //std::cout<<"div0"<<std::endl;
+                // std::cout<<"div0"<<std::endl;
                 ;
             } else {
                 lamda = *sum_nom_data / *Av_data;
                 if (lamda < min_plus && lamda > 0) {
                     min_plus = lamda;
-                    if (pos) facet = i;
-                }else if (lamda > max_minus && lamda < 0) max_minus = lamda;
+                    if (pos)
+                        facet = i;
+                } else if (lamda > max_minus && lamda < 0)
+                    max_minus = lamda;
             }
 
             Av_data++;
             sum_nom_data++;
         }
-        if (pos) return std::make_pair(min_plus, facet);
+        if (pos)
+            return std::make_pair(min_plus, facet);
         return std::make_pair(min_plus, max_minus);
     }
 
-    std::pair<NT,NT> line_intersect(Point const& r,
-                                    Point const& v,
-                                    VT& Ar,
-                                    VT& Av,
-                                    NT const& lambda_prev,
-                                    bool pos = false) const
-    {
+    std::pair<NT, NT> line_intersect(Point const &r, Point const &v, VT &Ar,
+                                     VT &Av, NT const &lambda_prev,
+                                     bool pos = false) const {
 
         NT lamda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
-        VT  sum_nom;
+        VT sum_nom;
         NT mult;
-        //unsigned int i, j;
+        // unsigned int i, j;
         unsigned int j;
         int m = num_of_hyperplanes(), facet;
 
-        Ar.noalias() += lambda_prev*Av;
+        Ar.noalias() += lambda_prev * Av;
         sum_nom = b - Ar;
         Av.noalias() = A * v.getCoefficients();
 
-        NT* sum_nom_data = sum_nom.data();
-        NT* Av_data = Av.data();
+        NT *sum_nom_data = sum_nom.data();
+        NT *Av_data = Av.data();
 
         for (int i = 0; i < m; i++) {
             if (*Av_data == NT(0)) {
-                //std::cout<<"div0"<<std::endl;
+                // std::cout<<"div0"<<std::endl;
                 ;
             } else {
                 lamda = *sum_nom_data / *Av_data;
                 if (lamda < min_plus && lamda > 0) {
                     min_plus = lamda;
-                    if (pos) facet = i;
-                }else if (lamda > max_minus && lamda < 0) max_minus = lamda;
+                    if (pos)
+                        facet = i;
+                } else if (lamda > max_minus && lamda < 0)
+                    max_minus = lamda;
             }
             Av_data++;
             sum_nom_data++;
         }
-        if (pos) return std::make_pair(min_plus, facet);
+        if (pos)
+            return std::make_pair(min_plus, facet);
         return std::make_pair(min_plus, max_minus);
     }
 
-
     // compute intersection point of a ray starting from r and pointing to v
     // with polytope discribed by A and b
-    std::pair<NT, int> line_positive_intersect(Point const& r,
-                                               Point const& v,
-                                               VT& Ar,
-                                               VT& Av) const
-    {
+    std::pair<NT, int> line_positive_intersect(Point const &r, Point const &v,
+                                               VT &Ar, VT &Av) const {
         return line_intersect(r, v, Ar, Av, true);
     }
 
-
     // compute intersection point of a ray starting from r and pointing to v
     // with polytope discribed by A and b
-    std::pair<NT, int> line_positive_intersect(Point const& r,
-                                               Point const& v,
-                                               VT& Ar,
-                                               VT& Av,
-                                               NT const& lambda_prev) const
-    {
+    std::pair<NT, int> line_positive_intersect(Point const &r, Point const &v,
+                                               VT &Ar, VT &Av,
+                                               NT const &lambda_prev) const {
         return line_intersect(r, v, Ar, Av, lambda_prev, true);
     }
 
-
-    //---------------------------accelarated billiard----------------------------------
+    //---------------------------accelarated
+    //billiard----------------------------------
     // compute intersection point of a ray starting from r and pointing to v
     // with polytope discribed by A and b
     template <typename update_parameters>
-    std::pair<NT, int> line_first_positive_intersect(Point const& r,
-                                                     Point const& v,
-                                                     VT& Ar,
-                                                     VT& Av,
-                                                     update_parameters& params) const
-    {
+    std::pair<NT, int>
+    line_first_positive_intersect(Point const &r, Point const &v, VT &Ar,
+                                  VT &Av, update_parameters &params) const {
         NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         NT lamda = 0;
         VT sum_nom;
         int m = num_of_hyperplanes();
-        int facet=-1;      
+        int facet = -1;
 
         Ar.noalias() = A * r.getCoefficients();
         sum_nom.noalias() = b - Ar;
         Av.noalias() = A * v.getCoefficients();
 
-        NT* Av_data = Av.data();
-        NT* sum_nom_data = sum_nom.data();
+        NT *Av_data = Av.data();
+        NT *sum_nom_data = sum_nom.data();
 
-        for (int i = 0; i < m; ++i, ++Av_data, ++sum_nom_data)
-        {
-            // this condition will evaluate differently for billiard SB / accelerated billiard
-            // Billiard SB: sum_nom_data is close to 0 => skipping the facet
-            // Accelerated Billiard: sum_nom_data far from 0 => not skipping the facet 
-            if (i == params.facet_prev && std::abs(*sum_nom_data) <= NT(1e-12)) continue;
+        for (int i = 0; i < m; ++i, ++Av_data, ++sum_nom_data) {
+            // this condition will evaluate differently for billiard SB /
+            // accelerated billiard Billiard SB: sum_nom_data is close to 0 =>
+            // skipping the facet Accelerated Billiard: sum_nom_data far from 0
+            // => not skipping the facet
+            if (i == params.facet_prev && std::abs(*sum_nom_data) <= NT(1e-12))
+                continue;
 
             NT lambda = *sum_nom_data / *Av_data;
             if (lambda > 0 && lambda < min_plus) {
-                min_plus= lambda;
+                min_plus = lambda;
                 facet = i;
                 params.inner_vi_ak = *Av_data;
             }
@@ -531,22 +476,15 @@ public:
 
         params.facet_prev = facet;
         return {min_plus, facet};
-
     }
 
-
-
     template <typename update_parameters>
-    std::pair<NT, int> line_positive_intersect(Point const& r,
-                                                     Point const& v,
-                                                     VT& Ar,
-                                                     VT& Av,
-                                                     NT const& lambda_prev,
-                                                     DenseMT const& AA,
-                                                     update_parameters& params) const
-    {
+    std::pair<NT, int>
+    line_positive_intersect(Point const &r, Point const &v, VT &Ar, VT &Av,
+                            NT const &lambda_prev, DenseMT const &AA,
+                            update_parameters &params) const {
 
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         NT lamda = 0;
@@ -555,20 +493,22 @@ public:
         int m = num_of_hyperplanes(), facet;
         int skip = params.facet_prev;
 
-        Ar.noalias() += lambda_prev*Av;
-        if(params.hit_ball) {
+        Ar.noalias() += lambda_prev * Av;
+        if (params.hit_ball) {
             Av.noalias() += (-2.0 * inner_prev) * (Ar / params.ball_inner_norm);
         } else {
             Av.noalias() += ((-2.0 * inner_prev) * AA.col(params.facet_prev));
         }
         sum_nom.noalias() = b - Ar;
 
-        NT* sum_nom_data = sum_nom.data();
-        NT* Av_data = Av.data();
+        NT *sum_nom_data = sum_nom.data();
+        NT *Av_data = Av.data();
 
-        for (int i = 0; i < m; ++i, ++Av_data, ++sum_nom_data){
-            if (i == skip) continue;    
-            if (*Av_data == NT(0)) continue;
+        for (int i = 0; i < m; ++i, ++Av_data, ++sum_nom_data) {
+            if (i == skip)
+                continue;
+            if (*Av_data == NT(0))
+                continue;
 
             lamda = *sum_nom_data / *Av_data;
             if (lamda < min_plus && lamda > 0) {
@@ -581,27 +521,25 @@ public:
         return std::pair<NT, int>(min_plus, facet);
     }
 
-
-
     template <typename update_parameters, typename set_type, typename AA_type>
-    std::pair<NT, int> line_positive_intersect(Point const& r,
-                                                     VT& Ar,
-                                                     VT& Av,
-                                                     NT const& lambda_prev,
-                                                     set_type& distances_set,
-                                                     AA_type const& AA,
-                                                     update_parameters& params) const
-    {
+    std::pair<NT, int>
+    line_positive_intersect(Point const &r, VT &Ar, VT &Av,
+                            NT const &lambda_prev, set_type &distances_set,
+                            AA_type const &AA,
+                            update_parameters &params) const {
         NT inner_prev = params.inner_vi_ak;
-        NT* Av_data = Av.data();
+        NT *Av_data = Av.data();
 
-        // Updating Av due to the change in direction caused by the previous reflection
-        // Av += (-2.0 * inner_prev) * AA.col(params.facet_prev)
+        // Updating Av due to the change in direction caused by the previous
+        // reflection Av += (-2.0 * inner_prev) * AA.col(params.facet_prev)
 
-        for (Eigen::SparseMatrix<double>::InnerIterator it(AA, params.facet_prev); it; ++it) {
+        for (Eigen::SparseMatrix<double>::InnerIterator it(AA,
+                                                           params.facet_prev);
+             it; ++it) {
 
-            // val(row) - params.moved_dist = The distance until we would hit the facet given by row
-            // all those values are stored inside distances_set for quick retrieval of the minimum
+            // val(row) - params.moved_dist = The distance until we would hit
+            // the facet given by row all those values are stored inside
+            // distances_set for quick retrieval of the minimum
 
             // Before updating Av(row)
             // val(row) = (b(row) - Ar(row)) / Av(row) + params.moved_dist
@@ -612,20 +550,28 @@ public:
             *(Av_data + it.row()) += (-2.0 * inner_prev) * it.value();
 
             // After updating Av(row)
-            // b(row) - Ar(row) = (old_val(row) - params.moved_dist) * old_Av(row) 
-            // new_val(row) = (b(row) - Ar(row)                                ) / new_Av(row) + params.moved_dist 
-            // new_val(row) = ((old_val(row) - params.moved_dist) * old_Av(row)) / new_Av(row) + params.moved_dist
-            
-            // new_val(row) = (old_val(row) - params.moved_dist) * old_Av(row)                                   / new_Av(row) + params.moved_dist;
-            // new_val(row) = (old_val(row) - params.moved_dist) * (new_Av(row) + 2.0 * inner_prev * it.value()) / new_Av(row) + params.moved_dist;
-            // new_val(row) = (old_val(row) - params.moved_dist) * (1 + (2.0 * inner_prev * it.value()) / new_Av(row) ) + params.moved_dist;
+            // b(row) - Ar(row) = (old_val(row) - params.moved_dist) *
+            // old_Av(row) new_val(row) = (b(row) - Ar(row) ) / new_Av(row) +
+            // params.moved_dist new_val(row) = ((old_val(row) -
+            // params.moved_dist) * old_Av(row)) / new_Av(row) +
+            // params.moved_dist
 
-            // new_val(row) = old_val(row) + (old_val(row) - params.moved_dist) * 2.0 * inner_prev * it.value() / new_Av(row)
+            // new_val(row) = (old_val(row) - params.moved_dist) * old_Av(row)
+            // / new_Av(row) + params.moved_dist; new_val(row) = (old_val(row) -
+            // params.moved_dist) * (new_Av(row) + 2.0 * inner_prev *
+            // it.value()) / new_Av(row) + params.moved_dist; new_val(row) =
+            // (old_val(row) - params.moved_dist) * (1 + (2.0 * inner_prev *
+            // it.value()) / new_Av(row) ) + params.moved_dist;
 
-            // val(row) += (val(row) - params.moved_dist) * 2.0 * inner_prev * it.value() / *(Av_data + it.row());
+            // new_val(row) = old_val(row) + (old_val(row) - params.moved_dist)
+            // * 2.0 * inner_prev * it.value() / new_Av(row)
+
+            // val(row) += (val(row) - params.moved_dist) * 2.0 * inner_prev *
+            // it.value() / *(Av_data + it.row());
 
             NT val = distances_set.get_val(it.row());
-            val += (val - params.moved_dist) * 2.0 * inner_prev * it.value() / *(Av_data + it.row());
+            val += (val - params.moved_dist) * 2.0 * inner_prev * it.value() /
+                   *(Av_data + it.row());
             distances_set.change_val(it.row(), val, params.moved_dist);
         }
 
@@ -641,16 +587,12 @@ public:
         return ans;
     }
 
-
     template <typename update_parameters>
-    std::pair<NT, int> line_positive_intersect(Point const& r,
-                                               Point const& v,
-                                               VT& Ar,
-                                               VT& Av,
-                                               NT const& lambda_prev,
-                                               update_parameters& params) const
-    {
-        NT min_plus  = std::numeric_limits<NT>::max();
+    std::pair<NT, int>
+    line_positive_intersect(Point const &r, Point const &v, VT &Ar, VT &Av,
+                            NT const &lambda_prev,
+                            update_parameters &params) const {
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         NT lamda = 0;
@@ -658,16 +600,18 @@ public:
         int m = num_of_hyperplanes(), facet;
         int skip = params.facet_prev;
 
-        Ar.noalias() += lambda_prev*Av;
+        Ar.noalias() += lambda_prev * Av;
         sum_nom.noalias() = b - Ar;
         Av.noalias() = A * v.getCoefficients();
 
-        NT* sum_nom_data = sum_nom.data();
-        NT* Av_data = Av.data();
+        NT *sum_nom_data = sum_nom.data();
+        NT *Av_data = Av.data();
 
         for (int i = 0; i < m; ++i, ++Av_data, ++sum_nom_data) {
-            if (i == skip) continue;
-            if (*Av_data == NT(0)) continue;
+            if (i == skip)
+                continue;
+            if (*Av_data == NT(0))
+                continue;
             lamda = *sum_nom_data / *Av_data;
             if (lamda < min_plus && lamda > 0) {
                 min_plus = lamda;
@@ -678,16 +622,18 @@ public:
         params.facet_prev = facet;
         return std::pair<NT, int>(min_plus, facet);
     }
-    
 
-    template<typename Params>
-    std::pair<NT,int> sparse_line_positive_intersect(Point const& r_rounded,
-                                                    Point const& v_rounded,
-                                                    VT& Ar, VT& Av,
-                                                    Params &params) const
-    {
-        VT r_orig = params.L_inv.transpose().template triangularView<Eigen::Lower>().solve(r_rounded.getCoefficients());
-        VT v_orig = params.L_inv.transpose().template triangularView<Eigen::Lower>().solve(v_rounded.getCoefficients());
+    template <typename Params>
+    std::pair<NT, int> sparse_line_positive_intersect(Point const &r_rounded,
+                                                      Point const &v_rounded,
+                                                      VT &Ar, VT &Av,
+                                                      Params &params) const {
+        VT r_orig = params.L_inv.transpose()
+                        .template triangularView<Eigen::Lower>()
+                        .solve(r_rounded.getCoefficients());
+        VT v_orig = params.L_inv.transpose()
+                        .template triangularView<Eigen::Lower>()
+                        .solve(v_rounded.getCoefficients());
 
         NT lambda_min = std::numeric_limits<NT>::max();
         int facet = -1;
@@ -695,8 +641,7 @@ public:
         Ar = params.A_original * r_orig;
         Av = params.A_original * v_orig;
 
-        for (int i = 0; i < params.A_original.rows(); ++i)
-        {
+        for (int i = 0; i < params.A_original.rows(); ++i) {
             NT b = params.b_original(i);
             if (std::abs(Av(i)) > NT(1e-12)) {
                 NT lambda = (b - Ar(i)) / Av(i);
@@ -714,13 +659,17 @@ public:
         return {lambda_min, facet};
     }
 
-    template<typename Params>
-    std::pair<NT,int> sparse_line_positive_intersect(Point const& r_rounded, Point const& v_rounded,
-                                                    VT& Ar, VT& Av, NT lambda_prev,
-                                                    Params &params) const
-    {
-        VT r_orig = params.L_inv.transpose().template triangularView<Eigen::Lower>().solve(r_rounded.getCoefficients());
-        VT v_orig = params.L_inv.transpose().template triangularView<Eigen::Lower>().solve(v_rounded.getCoefficients());
+    template <typename Params>
+    std::pair<NT, int>
+    sparse_line_positive_intersect(Point const &r_rounded,
+                                   Point const &v_rounded, VT &Ar, VT &Av,
+                                   NT lambda_prev, Params &params) const {
+        VT r_orig = params.L_inv.transpose()
+                        .template triangularView<Eigen::Lower>()
+                        .solve(r_rounded.getCoefficients());
+        VT v_orig = params.L_inv.transpose()
+                        .template triangularView<Eigen::Lower>()
+                        .solve(v_rounded.getCoefficients());
 
         Ar.noalias() += lambda_prev * Av;
         Av = params.A_original * v_orig;
@@ -728,8 +677,7 @@ public:
         NT lambda_min = std::numeric_limits<NT>::max();
         int facet = -1;
 
-        for (int i = 0; i < params.A_original.rows(); ++i)
-        {
+        for (int i = 0; i < params.A_original.rows(); ++i) {
             NT b = params.b_original(i);
             if (std::abs(Av(i)) > NT(1e-12)) {
                 NT lambda = (b - Ar(i)) / Av(i);
@@ -748,15 +696,13 @@ public:
     }
     //-----------------------------------------------------------------------------------//
 
-
-    //First coordinate ray intersecting convex polytope
-    std::pair<NT,NT> line_intersect_coord(Point const& r,
-                                          unsigned int const& rand_coord,
-                                          VT& lamdas) const
-    {
+    // First coordinate ray intersecting convex polytope
+    std::pair<NT, NT> line_intersect_coord(Point const &r,
+                                           unsigned int const &rand_coord,
+                                           VT &lamdas) const {
 
         NT lamda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
         VT sum_denom;
 
@@ -765,19 +711,20 @@ public:
         sum_denom = A.col(rand_coord);
         lamdas.noalias() = b - A * r.getCoefficients();
 
-        NT* lamda_data = lamdas.data();
-        NT* sum_denom_data = sum_denom.data();
+        NT *lamda_data = lamdas.data();
+        NT *sum_denom_data = sum_denom.data();
 
         for (int i = 0; i < m; i++) {
 
             if (*sum_denom_data == NT(0)) {
-                //std::cout<<"div0"<<sum_denom<<std::endl;
+                // std::cout<<"div0"<<sum_denom<<std::endl;
                 ;
             } else {
                 lamda = *lamda_data * (1 / *sum_denom_data);
-                if (lamda < min_plus && lamda > 0) min_plus = lamda;
-                if (lamda > max_minus && lamda < 0) max_minus = lamda;
-
+                if (lamda < min_plus && lamda > 0)
+                    min_plus = lamda;
+                if (lamda > max_minus && lamda < 0)
+                    max_minus = lamda;
             }
             lamda_data++;
             sum_denom_data++;
@@ -785,76 +732,78 @@ public:
         return std::make_pair(min_plus, max_minus);
     }
 
-
-    //Not the first coordinate ray intersecting convex
-    std::pair<NT,NT> line_intersect_coord(Point const& r,
-                                          Point const& r_prev,
-                                          unsigned int const& rand_coord,
-                                          unsigned int const& rand_coord_prev,
-                                          VT& lamdas) const
-    {
+    // Not the first coordinate ray intersecting convex
+    std::pair<NT, NT> line_intersect_coord(Point const &r, Point const &r_prev,
+                                           unsigned int const &rand_coord,
+                                           unsigned int const &rand_coord_prev,
+                                           VT &lamdas) const {
         NT lamda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         int m = num_of_hyperplanes();
 
-        lamdas.noalias() += (DenseMT)(A.col(rand_coord_prev)
-                         * (r_prev[rand_coord_prev] - r[rand_coord_prev]));
-        NT* data = lamdas.data();
+        lamdas.noalias() +=
+            (DenseMT)(A.col(rand_coord_prev) *
+                      (r_prev[rand_coord_prev] - r[rand_coord_prev]));
+        NT *data = lamdas.data();
 
         for (int i = 0; i < m; i++) {
             NT a = A.coeff(i, rand_coord);
 
             if (a == NT(0)) {
-                //std::cout<<"div0"<<std::endl;
+                // std::cout<<"div0"<<std::endl;
                 ;
             } else {
                 lamda = *data / a;
-                if (lamda < min_plus && lamda > 0) min_plus = lamda;
-                if (lamda > max_minus && lamda < 0) max_minus = lamda;
-
+                if (lamda < min_plus && lamda > 0)
+                    min_plus = lamda;
+                if (lamda > max_minus && lamda < 0)
+                    max_minus = lamda;
             }
             data++;
         }
         return std::make_pair(min_plus, max_minus);
     }
 
+    //------------------------------oracles for exponential
+    //sampling---------------//////
 
-    //------------------------------oracles for exponential sampling---------------//////
-
-    std::pair<NT, int> get_positive_quadratic_root(Point const& r, //current poistion
-                                                   Point const& v, // current velocity
-                                                   VT& Ac, // the product Ac where c is the bias vector of the exponential distribution
-                                                   NT const& T, // the variance of the exponential distribution
-                                                   VT& Ar, // the product Ar
-                                                   VT& Av, // the product Av
-                                                   int& facet_prev) const //the facet that the trajectory hit in the previous reflection
+    std::pair<NT, int> get_positive_quadratic_root(
+        Point const &r, // current poistion
+        Point const &v, // current velocity
+        VT &Ac, // the product Ac where c is the bias vector of the exponential
+                // distribution
+        NT const &T, // the variance of the exponential distribution
+        VT &Ar,      // the product Ar
+        VT &Av,      // the product Av
+        int &facet_prev)
+        const // the facet that the trajectory hit in the previous reflection
     {
         NT lamda = 0;
-        NT lamda2 =0;
-        NT lamda1 =0;
+        NT lamda2 = 0;
+        NT lamda1 = 0;
         NT alpha;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         VT sum_nom;
         int m = num_of_hyperplanes();
         int facet = -1;
 
         sum_nom = Ar - b;
-        Av.noalias() = A * v.getCoefficients();;
+        Av.noalias() = A * v.getCoefficients();
+        ;
 
-        NT* Av_data = Av.data();
-        NT* sum_nom_data = sum_nom.data();
-        NT* Ac_data = Ac.data();
+        NT *Av_data = Av.data();
+        NT *sum_nom_data = sum_nom.data();
+        NT *Ac_data = Ac.data();
 
-        for (int i = 0; i < m; i++)
-        {
+        for (int i = 0; i < m; i++) {
             alpha = -((*Ac_data) / (2.0 * T));
-            if (solve_quadratic_polynomial(alpha, (*Av_data), (*sum_nom_data), lamda1, lamda2))
-            {
-                lamda = pick_first_intersection_time_with_boundary(lamda1, lamda2, i, facet_prev);
-                if (lamda < min_plus && lamda > 0)
-                {
+            if (solve_quadratic_polynomial(alpha, (*Av_data), (*sum_nom_data),
+                                           lamda1, lamda2)) {
+                lamda = pick_first_intersection_time_with_boundary(
+                    lamda1, lamda2, i, facet_prev);
+                if (lamda < min_plus && lamda > 0) {
                     min_plus = lamda;
                     facet = i;
                 }
@@ -867,38 +816,45 @@ public:
         return std::make_pair(min_plus, facet);
     }
 
-
     // compute intersection points of a ray starting from r and pointing to v
     // with polytope discribed by A and b
-    std::pair<NT, int> quadratic_positive_intersect(Point const& r, //current poistion
-                                                    Point const& v, // current velocity
-                                                    VT& Ac, // the product Ac where c is the bias vector of the exponential distribution
-                                                    NT const& T, // the variance of the exponential distribution
-                                                    VT& Ar, // the product Ar
-                                                    VT& Av, // the product Av
-                                                    int& facet_prev) const //the facet that the trajectory hit in the previous reflection
+    std::pair<NT, int> quadratic_positive_intersect(
+        Point const &r, // current poistion
+        Point const &v, // current velocity
+        VT &Ac, // the product Ac where c is the bias vector of the exponential
+                // distribution
+        NT const &T, // the variance of the exponential distribution
+        VT &Ar,      // the product Ar
+        VT &Av,      // the product Av
+        int &facet_prev)
+        const // the facet that the trajectory hit in the previous reflection
     {
         Ar.noalias() = A * r.getCoefficients();
         return get_positive_quadratic_root(r, v, Ac, T, Ar, Av, facet_prev);
     }
 
-    std::pair<NT, int> quadratic_positive_intersect(Point const& r, //current poistion
-                                                    Point const& v, // current velocity
-                                                    VT& Ac,  // the product Ac where c is the bias vector of the exponential distribution
-                                                    NT const& T, // the variance of the exponential distribution
-                                                    VT& Ar, // the product Ar
-                                                    VT& Av, // the product Av
-                                                    NT const& lambda_prev, // the intersection time of the previous reflection
-                                                    int& facet_prev) const //the facet that the trajectory hit in the previous reflection
+    std::pair<NT, int> quadratic_positive_intersect(
+        Point const &r, // current poistion
+        Point const &v, // current velocity
+        VT &Ac, // the product Ac where c is the bias vector of the exponential
+                // distribution
+        NT const &T, // the variance of the exponential distribution
+        VT &Ar,      // the product Ar
+        VT &Av,      // the product Av
+        NT const
+            &lambda_prev, // the intersection time of the previous reflection
+        int &facet_prev)
+        const // the facet that the trajectory hit in the previous reflection
     {
-        Ar.noalias() += ((lambda_prev * lambda_prev) / (-2.0*T)) * Ac + lambda_prev * Av;
+        Ar.noalias() +=
+            ((lambda_prev * lambda_prev) / (-2.0 * T)) * Ac + lambda_prev * Av;
         return get_positive_quadratic_root(r, v, Ac, T, Ar, Av, facet_prev);
     }
 
-    NT pick_first_intersection_time_with_boundary(NT const& lamda1, NT const& lamda2, int const& current_facet, int const& previous_facet) const
-    {
-        if (lamda1 == lamda2)
-        {
+    NT pick_first_intersection_time_with_boundary(
+        NT const &lamda1, NT const &lamda2, int const &current_facet,
+        int const &previous_facet) const {
+        if (lamda1 == lamda2) {
             return lamda1;
         }
         NT lamda;
@@ -906,32 +862,34 @@ public:
         std::pair<NT, NT> minmax_values = std::minmax(lamda1, lamda2);
 
         lamda = (previous_facet == current_facet)
-            ? minmax_values.second < NT(tol) ? minmax_values.first : minmax_values.second
-            : minmax_values.second;
+                    ? minmax_values.second < NT(tol) ? minmax_values.first
+                                                     : minmax_values.second
+                    : minmax_values.second;
 
-        if (lamda1 * lamda2 < NT(0))
-        {
+        if (lamda1 * lamda2 < NT(0)) {
             lamda = (previous_facet == current_facet)
-            ? (minmax_values.second < NT(tol)) ? minmax_values.first : minmax_values.second
-            : minmax_values.second;
-        }
-        else
-        {
+                        ? (minmax_values.second < NT(tol))
+                              ? minmax_values.first
+                              : minmax_values.second
+                        : minmax_values.second;
+        } else {
             lamda = (previous_facet == current_facet)
-            ? (minmax_values.first >= NT(0) && minmax_values.first < NT(tol))
-            ? minmax_values.second : minmax_values.first
-            : minmax_values.first;
+                        ? (minmax_values.first >= NT(0) &&
+                           minmax_values.first < NT(tol))
+                              ? minmax_values.second
+                              : minmax_values.first
+                        : minmax_values.first;
         }
         return lamda;
     }
 
-
     // Boundary oracle for exact hmc spherical gaussian sampling
     // compute intersection point of ray starting from r and pointing to v
     // with polytope discribed by A and b (the ray describes a curve)
-    std::pair<NT, int> trigonometric_positive_intersect(Point const& r, Point const& v,
-                                                        NT const& omega, int &facet_prev) const
-    {
+    std::pair<NT, int> trigonometric_positive_intersect(Point const &r,
+                                                        Point const &v,
+                                                        NT const &omega,
+                                                        int &facet_prev) const {
         constexpr NT pi_2 = NT(2.0) * M_PI;
         NT t = std::numeric_limits<NT>::max();
 
@@ -943,18 +901,20 @@ public:
         sum_nom.noalias() = A * r.getCoefficients();
         sum_denom.noalias() = A * v.getCoefficients();
 
-        NT* sum_nom_data = sum_nom.data();
-        NT* sum_denom_data = sum_denom.data();
-        const NT* b_data = b.data();
+        NT *sum_nom_data = sum_nom.data();
+        NT *sum_denom_data = sum_denom.data();
+        const NT *b_data = b.data();
 
         const NT omega_sqr = omega * omega;
         const NT pi_2_omega = pi_2 / omega;
 
         for (int i = 0; i < m; i++) {
 
-            NT C = std::sqrt((*sum_nom_data) * (*sum_nom_data) + ((*sum_denom_data) * (*sum_denom_data))
-              / omega_sqr);
-            NT Phi = std::atan((-(*sum_denom_data)) / ((*sum_nom_data) * omega));
+            NT C =
+                std::sqrt((*sum_nom_data) * (*sum_nom_data) +
+                          ((*sum_denom_data) * (*sum_denom_data)) / omega_sqr);
+            NT Phi =
+                std::atan((-(*sum_denom_data)) / ((*sum_nom_data) * omega));
 
             if ((*sum_denom_data) < 0.0 && Phi < 0.0) {
                 Phi += M_PI;
@@ -965,12 +925,12 @@ public:
             if (C > (*b_data)) {
                 NT acos_b = std::acos((*b_data) / C);
                 NT t1 = (acos_b - Phi) / omega;
-                if (facet_prev == i && std::abs(t1) < 1e-10){
+                if (facet_prev == i && std::abs(t1) < 1e-10) {
                     t1 = pi_2_omega;
                 }
 
                 NT t2 = (-acos_b - Phi) / omega;
-                if (facet_prev == i && std::abs(t2) < 1e-10){
+                if (facet_prev == i && std::abs(t2) < 1e-10) {
                     t2 = pi_2_omega;
                 }
 
@@ -993,11 +953,9 @@ public:
         return std::make_pair(t, facet);
     }
 
-
-    // Apply linear transformation, of square matrix T^{-1}, in H-polytope P:= Ax<=b
-    template<typename T_type>
-    void linear_transformIt(T_type const& T)
-    {
+    // Apply linear transformation, of square matrix T^{-1}, in H-polytope P:=
+    // Ax<=b
+    template <typename T_type> void linear_transformIt(T_type const &T) {
         if constexpr (std::is_same<MT, DenseMT>::value) {
             A = A * T;
         } else {
@@ -1007,23 +965,19 @@ public:
         has_ball = false;
     }
 
-
     // shift polytope by a point c
 
-    void shift(const VT &c)
-    {
-        b -= A*c;
+    void shift(const VT &c) {
+        b -= A * c;
         has_ball = false;
     }
 
-
     // return for each facet the distance from the origin
-    std::vector<NT> get_dists(NT const& radius) const
-    {
-        unsigned int i=0;
-        std::vector <NT> dists(num_of_hyperplanes(), NT(0));
+    std::vector<NT> get_dists(NT const &radius) const {
+        unsigned int i = 0;
+        std::vector<NT> dists(num_of_hyperplanes(), NT(0));
         typename std::vector<NT>::iterator disit = dists.begin();
-        for ( ; disit!=dists.end(); disit++, i++)
+        for (; disit != dists.end(); disit++, i++)
             *disit = b(i) / A.row(i).norm();
 
         return dists;
@@ -1031,19 +985,14 @@ public:
 
     // no points given for the rounding, you have to sample from the polytope
     template <typename T>
-    bool get_points_for_rounding (T const& /*randPoints*/)
-    {
+    bool get_points_for_rounding(T const & /*randPoints*/) {
         return false;
     }
 
-    MT get_T() const
-    {
-        return A;
-    }
+    MT get_T() const { return A; }
 
-    void normalize()
-    {
-        if(normalized)
+    void normalize() {
+        if (normalized)
             return;
         NT row_norm;
         for (int i = 0; i < A.rows(); ++i) {
@@ -1056,120 +1005,138 @@ public:
         normalized = true;
     }
 
-    void compute_reflection(Point& v, Point const&, int const& facet) const
-    {
+    void compute_reflection(Point &v, Point const &, int const &facet) const {
         v += -2 * v.dot(A.row(facet)) * A.row(facet);
     }
 
     void resetFlags() {}
 
     NT log_barrier(Point &x, NT t = NT(100)) const {
-      int m = num_of_hyperplanes();
-      NT total = NT(0);
-      NT slack;
+        int m = num_of_hyperplanes();
+        NT total = NT(0);
+        NT slack;
 
-      for (int i = 0; i < m; i++) {
-        slack = b(i) - x.dot(A.row(i));
-        total += log(slack);
-      }
+        for (int i = 0; i < m; i++) {
+            slack = b(i) - x.dot(A.row(i));
+            total += log(slack);
+        }
 
-      return total / t;
+        return total / t;
     }
 
     Point grad_log_barrier(Point &x, NT t = NT(100)) {
-      int m = num_of_hyperplanes();
-      NT slack;
+        int m = num_of_hyperplanes();
+        NT slack;
 
-      Point total(x.dimension());
+        Point total(x.dimension());
 
-      for (int i = 0; i < m; i++) {
-        slack = b(i) - x.dot(A.row(i));
-        total = total + (1 / slack) * A.row(i);
-      }
-      total = (1.0 / t) * total;
-      return total;
+        for (int i = 0; i < m; i++) {
+            slack = b(i) - x.dot(A.row(i));
+            total = total + (1 / slack) * A.row(i);
+        }
+        total = (1.0 / t) * total;
+        return total;
     }
 
-    // Updates the velocity vector v and the position vector p after a reflection
+    // Updates the velocity vector v and the position vector p after a
+    // reflection
     template <typename update_parameters>
-    void compute_reflection(Point &v, Point const&, update_parameters const& params) const {
-            Point a((-2.0 * params.inner_vi_ak) * A.row(params.facet_prev));
-            v += a;
+    void compute_reflection(Point &v, Point const &,
+                            update_parameters const &params) const {
+        Point a((-2.0 * params.inner_vi_ak) * A.row(params.facet_prev));
+        v += a;
     }
 
-    template<typename Params>
-    void sparse_compute_reflection(Point &v_rounded, Params const &params) const
-    {
-        const VT& normalized_row = params.get_normalized_A_rounded_row(params.facet_prev);
+    template <typename Params>
+    void sparse_compute_reflection(Point &v_rounded,
+                                   Params const &params) const {
+        const VT &normalized_row =
+            params.get_normalized_A_rounded_row(params.facet_prev);
         NT dot_product = normalized_row.dot(v_rounded.getCoefficients());
         v_rounded += (-2.0 * dot_product) * Point(normalized_row);
-    } 
- 
+    }
 
     // Only to be called when MT is in RowMajor format
     // The real value of p is given by p + params.moved_dist * v
     template <typename update_parameters>
-    auto compute_reflection_abw_sparse(Point &v, Point &p, update_parameters const& params) const
-    {
-        NT* v_data = v.pointerToData();
-        NT* p_data = p.pointerToData();
-        for(Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(A, params.facet_prev); it; ++it) {
+    auto compute_reflection_abw_sparse(Point &v, Point &p,
+                                       update_parameters const &params) const {
+        NT *v_data = v.pointerToData();
+        NT *p_data = p.pointerToData();
+        for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(
+                 A, params.facet_prev);
+             it; ++it) {
             *(v_data + it.col()) += (-2.0 * params.inner_vi_ak) * it.value();
-            *(p_data + it.col()) -= (-2.0 * params.inner_vi_ak * params.moved_dist) * it.value();
+            *(p_data + it.col()) -=
+                (-2.0 * params.inner_vi_ak * params.moved_dist) * it.value();
         }
     }
 
     // function to compute reflection for GaBW random walk
     // compatible when the polytope is both dense or sparse
     template <typename DenseSparseMT, typename update_parameters>
-    NT compute_reflection(Point &v, Point &p, NT &vEv, DenseSparseMT const &AE, VT const &AEA, update_parameters const &params) const {
+    NT compute_reflection(Point &v, Point &p, NT &vEv, DenseSparseMT const &AE,
+                          VT const &AEA,
+                          update_parameters const &params) const {
 
-            NT new_vEv;
-            if constexpr (!std::is_same_v<MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>) {
-                Point a((-2.0 * params.inner_vi_ak) * A.row(params.facet_prev));
+        NT new_vEv;
+        if constexpr (!std::is_same_v<
+                          MT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>) {
+            Point a((-2.0 * params.inner_vi_ak) * A.row(params.facet_prev));
+            VT x = v.getCoefficients();
+            new_vEv = vEv - (4.0 * params.inner_vi_ak) *
+                                (AE.row(params.facet_prev).dot(x) -
+                                 params.inner_vi_ak * AEA(params.facet_prev));
+            v += a;
+        } else {
+
+            if constexpr (!std::is_same_v<
+                              DenseSparseMT,
+                              Eigen::SparseMatrix<NT, Eigen::RowMajor>>) {
                 VT x = v.getCoefficients();
-                new_vEv = vEv - (4.0 * params.inner_vi_ak) * (AE.row(params.facet_prev).dot(x) - params.inner_vi_ak * AEA(params.facet_prev));
-                v += a;
+                new_vEv =
+                    vEv - (4.0 * params.inner_vi_ak) *
+                              (AE.row(params.facet_prev).dot(x) -
+                               params.inner_vi_ak * AEA(params.facet_prev));
             } else {
-                
-                if constexpr(!std::is_same_v<DenseSparseMT, Eigen::SparseMatrix<NT, Eigen::RowMajor>>) {
-                    VT x = v.getCoefficients();
-                    new_vEv = vEv - (4.0 * params.inner_vi_ak) * (AE.row(params.facet_prev).dot(x) - params.inner_vi_ak * AEA(params.facet_prev));
-                } else {
-                    new_vEv = vEv + 4.0 * params.inner_vi_ak * params.inner_vi_ak * AEA(params.facet_prev);
-                    NT* v_data = v.pointerToData();
-                    for(Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(AE, params.facet_prev); it; ++it) {
-                        new_vEv -= 4.0 * params.inner_vi_ak * it.value() * *(v_data + it.col());
-                    }
-                }
-
-                NT* v_data = v.pointerToData();
-                NT* p_data = p.pointerToData();
-                for(Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(A, params.facet_prev); it; ++it) {
-                    *(v_data + it.col()) += (-2.0 * params.inner_vi_ak) * it.value();
-                    *(p_data + it.col()) -= (-2.0 * params.inner_vi_ak * params.moved_dist) * it.value();
+                new_vEv = vEv + 4.0 * params.inner_vi_ak * params.inner_vi_ak *
+                                    AEA(params.facet_prev);
+                NT *v_data = v.pointerToData();
+                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
+                         it(AE, params.facet_prev);
+                     it; ++it) {
+                    new_vEv -= 4.0 * params.inner_vi_ak * it.value() *
+                               *(v_data + it.col());
                 }
             }
-            NT coeff = std::sqrt(vEv / new_vEv);
-            vEv = new_vEv;
-            return coeff;
+
+            NT *v_data = v.pointerToData();
+            NT *p_data = p.pointerToData();
+            for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(
+                     A, params.facet_prev);
+                 it; ++it) {
+                *(v_data + it.col()) +=
+                    (-2.0 * params.inner_vi_ak) * it.value();
+                *(p_data + it.col()) -=
+                    (-2.0 * params.inner_vi_ak * params.moved_dist) *
+                    it.value();
+            }
+        }
+        NT coeff = std::sqrt(vEv / new_vEv);
+        vEv = new_vEv;
+        return coeff;
     }
 
-    void update_position_internal(NT&){}
+    void update_position_internal(NT &) {}
 
     template <class bfunc, class NonLinearOracle>
-    std::tuple<NT, Point, int> curve_intersect(
-      NT t_prev,
-      NT t0,
-      NT eta,
-      std::vector<Point> &coeffs,
-      bfunc phi,
-      bfunc grad_phi,
-      NonLinearOracle &intersection_oracle,
-      int ignore_facet=-1)
-    {
-        return intersection_oracle.apply(t_prev, t0, eta, A, b, *this,
-                                         coeffs, phi, grad_phi, ignore_facet);
+    std::tuple<NT, Point, int>
+    curve_intersect(NT t_prev, NT t0, NT eta, std::vector<Point> &coeffs,
+                    bfunc phi, bfunc grad_phi,
+                    NonLinearOracle &intersection_oracle,
+                    int ignore_facet = -1) {
+        return intersection_oracle.apply(t_prev, t0, eta, A, b, *this, coeffs,
+                                         phi, grad_phi, ignore_facet);
     }
 };
 

--- a/include/convex_bodies/hpolytope.h
+++ b/include/convex_bodies/hpolytope.h
@@ -145,8 +145,6 @@ public:
     {
         normalize();
         if (!has_ball) {
-            
-            has_ball = true;
             NT const tol = 1e-08;
             std::tuple<VT, NT, bool> inner_ball = max_inscribed_ball(A, b, 5000, tol);
 
@@ -154,17 +152,25 @@ public:
             if (is_in(Point(std::get<0>(inner_ball))) == 0 || std::get<1>(inner_ball) < tol/2.0 ||
                 std::isnan(std::get<1>(inner_ball)) || std::isinf(std::get<1>(inner_ball)) ||
                 is_inner_point_nan_inf(std::get<0>(inner_ball))) {
-                
+
                 std::cerr << "Failed to compute max inscribed ball, trying to use lpsolve" << std::endl;
                 #ifndef DISABLE_LPSOLVE
-                    _inner_ball = ComputeChebychevBall<NT, Point>(A, b); // use lpsolve library
+                    auto lp_result = ComputeChebychevBall<NT, Point>(A, b);
+                    if (lp_result.second >= tol/2.0) {
+                        _inner_ball = lp_result;
+                        has_ball = true;
+                    } else {
+                        std::cerr << "lpsolve also failed; polytope may not be full-dimensional" << std::endl;
+                        return {Point(_d), NT(-1)};
+                    }
                 #else
-                    std::cerr << "lpsolve is disabled, unable to compute inner ball";
-                    has_ball = false;
+                    std::cerr << "lpsolve is disabled, unable to compute inner ball" << std::endl;
+                    return {Point(_d), NT(-1)};
                 #endif
             } else {
                 _inner_ball.first = Point(std::get<0>(inner_ball));
                 _inner_ball.second = std::get<1>(inner_ball);
+                has_ball = true;
             }
         }
         return _inner_ball;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -385,6 +385,8 @@ add_test(NAME test_volumetric_center
           COMMAND test_internal_points -tc=test_volumetric_center)
 add_test(NAME test_vaidya_center
           COMMAND test_internal_points -tc=test_vaidya_center)
+add_test(NAME test_degenerate_inscribed_ball
+          COMMAND test_internal_points -tc=test_degenerate_inscribed_ball)
 
 add_executable (full_dimensional_polytope_test full_dimensional_polytope_test.cpp $<TARGET_OBJECTS:test_main>)
 add_test(NAME full_dimensional_polytope_canonical_simplex

--- a/test/test_internal_points.cpp
+++ b/test/test_internal_points.cpp
@@ -243,3 +243,45 @@ TEST_CASE("test_vaidya_center") {
 TEST_CASE("test_max_ball_sparse") {
     call_test_max_ball_sparse<double>();
 }
+
+template <typename NT>
+void call_test_degenerate_inscribed_ball() {
+    typedef Cartesian<NT> Kernel;
+    typedef typename Kernel::Point Point;
+    typedef HPolytope<Point> Hpolytope;
+    typedef typename Hpolytope::MT MT;
+    typedef typename Hpolytope::VT VT;
+
+    std::cout << "\n--- Testing inscribed ball for degenerate (non-full-dimensional) polytope" << std::endl;
+
+    // A 2D polytope (square) embedded in 3D space via z = 0 plane
+    // Constraints: +-x1 <= 1, +-x2 <= 1, x3 <= 0, -x3 <= 0
+    // The polytope has no interior in R^3, so no positive-radius ball exists.
+    MT A(6, 3);
+    VT b(6);
+    A << 1,  0,  0,
+        -1,  0,  0,
+         0,  1,  0,
+         0, -1,  0,
+         0,  0,  1,
+         0,  0, -1;
+    b << 1, 1, 1, 1, 0, 0;
+
+    Hpolytope P(3, A, b);
+    std::pair<Point, NT> inner_ball = P.ComputeInnerBall();
+
+    // Both solvers should fail gracefully and return a proper failure indicator.
+    // Radius must be negative (the sentinel for failure) and the center must
+    // have the correct ambient dimension (3), not a garbage 1-dimensional point.
+    CHECK(inner_ball.second < NT(0));
+    CHECK(inner_ball.first.dimension() == 3);
+
+    // Calling ComputeInnerBall a second time must also return a failure indicator
+    // without caching the bad result as if it were valid.
+    std::pair<Point, NT> inner_ball2 = P.ComputeInnerBall();
+    CHECK(inner_ball2.second < NT(0));
+}
+
+TEST_CASE("test_degenerate_inscribed_ball") {
+    call_test_degenerate_inscribed_ball<double>();
+}

--- a/test/test_internal_points.cpp
+++ b/test/test_internal_points.cpp
@@ -12,47 +12,49 @@
 
 #include <boost/random.hpp>
 
-#include "misc/misc.h"
 #include "cartesian_geom/cartesian_kernel.h"
 #include "convex_bodies/hpolytope.h"
+#include "misc/misc.h"
 
-#include "preprocess/max_inscribed_ball.hpp"
 #include "preprocess/barrier_center_ellipsoid.hpp"
+#include "preprocess/max_inscribed_ball.hpp"
 
-#include "generators/known_polytope_generators.h"
 #include "generators/h_polytopes_generator.h"
+#include "generators/known_polytope_generators.h"
 
 #include "convex_bodies/orderpolytope.h"
 #include "misc/poset.h"
 
-template <typename NT>
-void call_test_max_ball() {
-    typedef Cartesian <NT> Kernel;
+template <typename NT> void call_test_max_ball() {
+    typedef Cartesian<NT> Kernel;
     typedef typename Kernel::Point Point;
-    typedef HPolytope <Point> Hpolytope;
+    typedef HPolytope<Point> Hpolytope;
     typedef boost::mt19937 PolyRNGType;
     Hpolytope P;
 
-    std::cout << "\n--- Testing Chebychev ball for skinny H-polytope" << std::endl;
-    bool pre_rounding = true; // round random polytope before applying the skinny transformation
+    std::cout << "\n--- Testing Chebychev ball for skinny H-polytope"
+              << std::endl;
+    bool pre_rounding =
+        true; // round random polytope before applying the skinny transformation
     NT max_min_eig_ratio = NT(2000);
-    P = skinny_random_hpoly<Hpolytope, NT, PolyRNGType>(4, 180, pre_rounding, max_min_eig_ratio, 127);
+    P = skinny_random_hpoly<Hpolytope, NT, PolyRNGType>(4, 180, pre_rounding,
+                                                        max_min_eig_ratio, 127);
     P.normalize();
     std::pair<Point, NT> InnerBall = P.ComputeInnerBall();
 
     NT tol = 1e-08;
     unsigned int maxiter = 500;
-    auto [center, radius, converged] =  max_inscribed_ball(P.get_mat(), P.get_vec(), maxiter, tol);
+    auto [center, radius, converged] =
+        max_inscribed_ball(P.get_mat(), P.get_vec(), maxiter, tol);
     CHECK(P.is_in(Point(center)) == -1);
     CHECK(std::abs(radius - InnerBall.second) <= 1e-03);
     CHECK(converged);
 }
 
-template <typename NT>
-void call_test_max_ball_sparse() {
-    typedef Cartesian <NT> Kernel;
+template <typename NT> void call_test_max_ball_sparse() {
+    typedef Cartesian<NT> Kernel;
     typedef typename Kernel::Point Point;
-    typedef HPolytope <Point> Hpolytope;
+    typedef HPolytope<Point> Hpolytope;
     typedef boost::mt19937 PolyRNGType;
     typedef typename OrderPolytope<Point>::VT VT;
     typedef typename OrderPolytope<Point>::MT MT;
@@ -63,7 +65,7 @@ void call_test_max_ball_sparse() {
     // Create Poset, 4 elements, a0 <= a1, a0 <= a2, a1 <= a3
     RV poset_data{{0, 1}, {0, 2}, {1, 3}};
     Poset poset(4, poset_data);
-    
+
     // Initialize order polytope from the poset
     OrderPolytope<Point> OP(poset);
     OP.normalize();
@@ -71,68 +73,80 @@ void call_test_max_ball_sparse() {
     MT A = MT(OP.get_mat());
     VT b = OP.get_vec();
 
-    std::cout << "\n--- Testing Chebychev ball for sparse order Polytope" << std::endl;
+    std::cout << "\n--- Testing Chebychev ball for sparse order Polytope"
+              << std::endl;
 
     NT tol = 1e-08;
     unsigned int maxiter = 500;
-    auto [center, radius, converged] =  max_inscribed_ball(Asp, b, maxiter, tol);
-    auto [center2, radius2, converged2] =  max_inscribed_ball(A, b, maxiter, tol);
+    auto [center, radius, converged] = max_inscribed_ball(Asp, b, maxiter, tol);
+    auto [center2, radius2, converged2] =
+        max_inscribed_ball(A, b, maxiter, tol);
 
     VT center_(4);
     center_ << 0.207107, 0.5, 0.593398, 0.792893;
 
     CHECK(OP.is_in(Point(center)) == -1);
-    auto [E, x0, round_val] = inscribed_ellipsoid_rounding<MT, VT, NT>(OP, Point(center));
-    
+    auto [E, x0, round_val] =
+        inscribed_ellipsoid_rounding<MT, VT, NT>(OP, Point(center));
+
     CHECK((center - center_).norm() <= 1e-06);
     CHECK(std::abs(radius - 0.207107) <= 1e-06);
     CHECK(converged);
 }
 
-template <typename NT>
-void call_test_max_ball_feasibility() {
-    typedef Cartesian <NT> Kernel;
+template <typename NT> void call_test_max_ball_feasibility() {
+    typedef Cartesian<NT> Kernel;
     typedef typename Kernel::Point Point;
-    typedef HPolytope <Point> Hpolytope;
+    typedef HPolytope<Point> Hpolytope;
     typedef boost::mt19937 PolyRNGType;
     Hpolytope P;
 
-    std::cout << "\n--- Testing feasibility point for skinny H-polytope" << std::endl;
-    bool pre_rounding = true; // round random polytope before applying the skinny transformation 
+    std::cout << "\n--- Testing feasibility point for skinny H-polytope"
+              << std::endl;
+    bool pre_rounding =
+        true; // round random polytope before applying the skinny transformation
     NT max_min_eig_ratio = NT(2000);
-    P = skinny_random_hpoly<Hpolytope, NT, PolyRNGType>(50, 500, pre_rounding, max_min_eig_ratio, 127);
+    P = skinny_random_hpoly<Hpolytope, NT, PolyRNGType>(50, 500, pre_rounding,
+                                                        max_min_eig_ratio, 127);
     P.normalize();
 
     bool feasibility_only = true; // compute only a feasible point
     NT tol = 1e-08;
     unsigned int maxiter = 500;
-    auto [center, radius, converged] =  max_inscribed_ball(P.get_mat(), P.get_vec(), maxiter, tol, feasibility_only);
+    auto [center, radius, converged] = max_inscribed_ball(
+        P.get_mat(), P.get_vec(), maxiter, tol, feasibility_only);
 
     CHECK(P.is_in(Point(center)) == -1);
     CHECK(converged);
 }
 
-template <typename NT>
-void call_test_analytic_center() {
-    typedef Cartesian <NT> Kernel;
+template <typename NT> void call_test_analytic_center() {
+    typedef Cartesian<NT> Kernel;
     typedef typename Kernel::Point Point;
-    typedef HPolytope <Point> Hpolytope;
+    typedef HPolytope<Point> Hpolytope;
     typedef typename Hpolytope::MT MT;
     typedef typename Hpolytope::VT VT;
     typedef boost::mt19937 PolyRNGType;
     typedef Eigen::SparseMatrix<NT> SpMT;
     Hpolytope P;
 
-    std::cout << "\n--- Testing analytic center for skinny H-polytope" << std::endl;
-    bool pre_rounding = true; // round random polytope before applying the skinny transformation 
+    std::cout << "\n--- Testing analytic center for skinny H-polytope"
+              << std::endl;
+    bool pre_rounding =
+        true; // round random polytope before applying the skinny transformation
     NT max_min_eig_ratio = NT(100);
-    P = skinny_random_hpoly<Hpolytope, NT, PolyRNGType>(3, 15, pre_rounding, max_min_eig_ratio, 127);
+    P = skinny_random_hpoly<Hpolytope, NT, PolyRNGType>(3, 15, pre_rounding,
+                                                        max_min_eig_ratio, 127);
     P.normalize();
-    
-    auto [Hessian, analytic_center, converged] = barrier_center_ellipsoid_linear_ineq<MT, EllipsoidType::LOG_BARRIER, NT>(P.get_mat(), P.get_vec());
-    
+
+    auto [Hessian, analytic_center, converged] =
+        barrier_center_ellipsoid_linear_ineq<MT, EllipsoidType::LOG_BARRIER,
+                                             NT>(P.get_mat(), P.get_vec());
+
     SpMT Asp = P.get_mat().sparseView();
-    auto [Hessian_sp, analytic_center2, converged2] = barrier_center_ellipsoid_linear_ineq<MT, EllipsoidType::LOG_BARRIER, NT>(Asp, P.get_vec());
+    auto [Hessian_sp, analytic_center2, converged2] =
+        barrier_center_ellipsoid_linear_ineq<MT, EllipsoidType::LOG_BARRIER,
+                                             NT>(Asp, P.get_vec());
 
     CHECK(P.is_in(Point(analytic_center)) == -1);
     CHECK(converged);
@@ -149,26 +163,33 @@ void call_test_analytic_center() {
     CHECK((Hessian - Hessian_sp).norm() < 1e-12);
 }
 
-template <typename NT>
-void call_test_volumetric_center() {
-    typedef Cartesian <NT> Kernel;
+template <typename NT> void call_test_volumetric_center() {
+    typedef Cartesian<NT> Kernel;
     typedef typename Kernel::Point Point;
-    typedef HPolytope <Point> Hpolytope;
+    typedef HPolytope<Point> Hpolytope;
     typedef typename Hpolytope::MT MT;
     typedef typename Hpolytope::VT VT;
     typedef boost::mt19937 PolyRNGType;
     typedef Eigen::SparseMatrix<NT> SpMT;
     Hpolytope P;
 
-    std::cout << "\n--- Testing volumetric center for skinny H-polytope" << std::endl;
-    bool pre_rounding = true; // round random polytope before applying the skinny transformation 
+    std::cout << "\n--- Testing volumetric center for skinny H-polytope"
+              << std::endl;
+    bool pre_rounding =
+        true; // round random polytope before applying the skinny transformation
     NT max_min_eig_ratio = NT(100);
-    P = skinny_random_hpoly<Hpolytope, NT, PolyRNGType>(3, 15, pre_rounding, max_min_eig_ratio, 127);
+    P = skinny_random_hpoly<Hpolytope, NT, PolyRNGType>(3, 15, pre_rounding,
+                                                        max_min_eig_ratio, 127);
     P.normalize();
-    
-    auto [Hessian, volumetric_center, converged] = barrier_center_ellipsoid_linear_ineq<MT, EllipsoidType::VOLUMETRIC_BARRIER, NT>(P.get_mat(), P.get_vec());
+
+    auto [Hessian, volumetric_center, converged] =
+        barrier_center_ellipsoid_linear_ineq<
+            MT, EllipsoidType::VOLUMETRIC_BARRIER, NT>(P.get_mat(),
+                                                       P.get_vec());
     SpMT Asp = P.get_mat().sparseView();
-    auto [Hessian_sp, volumetric_center2, converged2] = barrier_center_ellipsoid_linear_ineq<MT, EllipsoidType::VOLUMETRIC_BARRIER, NT>(Asp, P.get_vec());
+    auto [Hessian_sp, volumetric_center2, converged2] =
+        barrier_center_ellipsoid_linear_ineq<
+            MT, EllipsoidType::VOLUMETRIC_BARRIER, NT>(Asp, P.get_vec());
     CHECK(P.is_in(Point(volumetric_center)) == -1);
     CHECK(converged);
     CHECK(std::abs(volumetric_center(0) + 1.49069) < 1e-04);
@@ -184,27 +205,33 @@ void call_test_volumetric_center() {
     CHECK((Hessian - Hessian_sp).norm() < 1e-12);
 }
 
-template <typename NT>
-void call_test_vaidya_center() {
-    typedef Cartesian <NT> Kernel;
+template <typename NT> void call_test_vaidya_center() {
+    typedef Cartesian<NT> Kernel;
     typedef typename Kernel::Point Point;
-    typedef HPolytope <Point> Hpolytope;
+    typedef HPolytope<Point> Hpolytope;
     typedef typename Hpolytope::MT MT;
     typedef typename Hpolytope::VT VT;
     typedef boost::mt19937 PolyRNGType;
     typedef Eigen::SparseMatrix<NT> SpMT;
     Hpolytope P;
 
-    std::cout << "\n--- Testing vaidya center for skinny H-polytope" << std::endl;
-    bool pre_rounding = true; // round random polytope before applying the skinny transformation 
+    std::cout << "\n--- Testing vaidya center for skinny H-polytope"
+              << std::endl;
+    bool pre_rounding =
+        true; // round random polytope before applying the skinny transformation
     NT max_min_eig_ratio = NT(100);
-    P = skinny_random_hpoly<Hpolytope, NT, PolyRNGType>(3, 15, pre_rounding, max_min_eig_ratio, 127);
+    P = skinny_random_hpoly<Hpolytope, NT, PolyRNGType>(3, 15, pre_rounding,
+                                                        max_min_eig_ratio, 127);
     P.normalize();
-    
-    auto [Hessian, vaidya_center, converged] = barrier_center_ellipsoid_linear_ineq<MT, EllipsoidType::VAIDYA_BARRIER, NT>(P.get_mat(), P.get_vec());
+
+    auto [Hessian, vaidya_center, converged] =
+        barrier_center_ellipsoid_linear_ineq<MT, EllipsoidType::VAIDYA_BARRIER,
+                                             NT>(P.get_mat(), P.get_vec());
     SpMT Asp = P.get_mat().sparseView();
-    auto [Hessian_sp, vaidya_center2, converged2] = barrier_center_ellipsoid_linear_ineq<MT, EllipsoidType::VAIDYA_BARRIER, NT>(Asp, P.get_vec());
-    
+    auto [Hessian_sp, vaidya_center2, converged2] =
+        barrier_center_ellipsoid_linear_ineq<MT, EllipsoidType::VAIDYA_BARRIER,
+                                             NT>(Asp, P.get_vec());
+
     CHECK(P.is_in(Point(vaidya_center)) == -1);
     CHECK(converged);
     CHECK(std::abs(vaidya_center(0) + 2.40686) < 1e-04);
@@ -220,64 +247,51 @@ void call_test_vaidya_center() {
     CHECK((Hessian - Hessian_sp).norm() < 1e-12);
 }
 
-TEST_CASE("test_max_ball") {
-    call_test_max_ball<double>();
-}
+TEST_CASE("test_max_ball") { call_test_max_ball<double>(); }
 
 TEST_CASE("test_feasibility_point") {
     call_test_max_ball_feasibility<double>();
 }
 
-TEST_CASE("test_analytic_center") {
-    call_test_analytic_center<double>();
-}
+TEST_CASE("test_analytic_center") { call_test_analytic_center<double>(); }
 
-TEST_CASE("test_volumetric_center") {
-    call_test_volumetric_center<double>();
-}
+TEST_CASE("test_volumetric_center") { call_test_volumetric_center<double>(); }
 
-TEST_CASE("test_vaidya_center") {
-    call_test_vaidya_center<double>();
-}
+TEST_CASE("test_vaidya_center") { call_test_vaidya_center<double>(); }
 
-TEST_CASE("test_max_ball_sparse") {
-    call_test_max_ball_sparse<double>();
-}
+TEST_CASE("test_max_ball_sparse") { call_test_max_ball_sparse<double>(); }
 
-template <typename NT>
-void call_test_degenerate_inscribed_ball() {
+template <typename NT> void call_test_degenerate_inscribed_ball() {
     typedef Cartesian<NT> Kernel;
     typedef typename Kernel::Point Point;
     typedef HPolytope<Point> Hpolytope;
     typedef typename Hpolytope::MT MT;
     typedef typename Hpolytope::VT VT;
 
-    std::cout << "\n--- Testing inscribed ball for degenerate (non-full-dimensional) polytope" << std::endl;
+    std::cout << "\n--- Testing inscribed ball for degenerate "
+                 "(non-full-dimensional) polytope"
+              << std::endl;
 
     // A 2D polytope (square) embedded in 3D space via z = 0 plane
     // Constraints: +-x1 <= 1, +-x2 <= 1, x3 <= 0, -x3 <= 0
     // The polytope has no interior in R^3, so no positive-radius ball exists.
     MT A(6, 3);
     VT b(6);
-    A << 1,  0,  0,
-        -1,  0,  0,
-         0,  1,  0,
-         0, -1,  0,
-         0,  0,  1,
-         0,  0, -1;
+    A << 1, 0, 0, -1, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 1, 0, 0, -1;
     b << 1, 1, 1, 1, 0, 0;
 
     Hpolytope P(3, A, b);
     std::pair<Point, NT> inner_ball = P.ComputeInnerBall();
 
-    // Both solvers should fail gracefully and return a proper failure indicator.
-    // Radius must be negative (the sentinel for failure) and the center must
-    // have the correct ambient dimension (3), not a garbage 1-dimensional point.
+    // Both solvers should fail gracefully and return a proper failure
+    // indicator. Radius must be negative (the sentinel for failure) and the
+    // center must have the correct ambient dimension (3), not a garbage
+    // 1-dimensional point.
     CHECK(inner_ball.second < NT(0));
     CHECK(inner_ball.first.dimension() == 3);
 
-    // Calling ComputeInnerBall a second time must also return a failure indicator
-    // without caching the bad result as if it were valid.
+    // Calling ComputeInnerBall a second time must also return a failure
+    // indicator without caching the bad result as if it were valid.
     std::pair<Point, NT> inner_ball2 = P.ComputeInnerBall();
     CHECK(inner_ball2.second < NT(0));
 }


### PR DESCRIPTION
##Overview                                                                                                                         
This PR addresses three critical stability issues in ComputeInnerBall within the volesti core. These bugs previously allowed for garbage data propagation and segmentation faults when handling non-full-dimensional H-polytopes.
                                                                                                                                   
 ## Root Causes Identified
  1. Premature State Flagging: has_ball = true was set before computation, allowing cached failures.
  2. Degeneracy Handling: Missing validation for lpsolve returning OPTIMAL with r=0 in degenerate cases (e.g., 2D in 3D).
  3. Uninitialized Sentinels: The DISABLE_LPSOLVE path left _inner_ball.second indeterminate.

 ## Technical Fixes
  - Standardized failure return to {Point(_d), NT(-1)} to maintain ambient dimension consistency.
  - Implemented lp_result.second >= tol/2.0 validation (aligning with IP solver thresholds).
  - Deferred has_ball assignment until solver success is confirmed.

 ## Regression Testing
  Added a new test case in test/test_internal_points.cpp:
  - Scenario: 2D square embedded in 3D (x3 ≤ 0, -x3 ≤ 0).
  - Verification: Confirms radius < 0, center.dimension() == 3, and ensures no false success on subsequent calls.
  - Run via: ctest -R test_degenerate_inscribed_ball --verbose
  - Closes #463
