### PR TITLE
Fix memory leak in RichardsonExtrapolationODESolver by adding missing destructor

### DIFF
--- a/include/ode_solvers/richardson_extrapolation.hpp
+++ b/include/ode_solvers/richardson_extrapolation.hpp
@@ -70,6 +70,9 @@ struct RichardsonExtrapolationODESolver {
   void initialize_solver() {
     solver = new RKODESolver<Point, NT, Polytope, func>(t, eta, xs, F, bounds{NULL});
   }
+  ~RichardsonExtrapolationODESolver() {
+      delete solver;
+  }
 
   void step(int k, bool accepted) {
     xs_prev = xs;


### PR DESCRIPTION
**Problem Description**
while running a test suite with address sanitizer [-fsanitize=address], discovered a memory leak originating in include/ode_solvers/richardson_extrapolation.hpp.

<img width="1920" height="1008" alt="Screenshot 2026-03-04 210132" src="https://github.com/user-attachments/assets/3d8d27c8-803a-4a17-896e-8c78405a12a8" />

**To reproduce**
1. Go inside your `build` directory
2. Run the sanitizer: cmake -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -O0 -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" ..
3. Run: make -j$(nproc) or make -j1 or make -j2 (according to your machine)
4. Run the test: ctest -R ode_solvers_test --output-on-failure

**Changes**
Added ~RichardsonExtrapolationODESolver() { delete solver; } to safely deallocate the pointer.

**Verification**
Compiled and ran ctest -R ode_solvers_test with ASan enabled. The test now passes completely clean with zero leaks reported.
<img width="1920" height="1008" alt="Screenshot 2026-03-04 214640" src="https://github.com/user-attachments/assets/20ba29d6-b890-4c61-9034-8d156f59a038" />

**Desktop**
-Windows (wsl to LINUX)
-Windows 11 (Ubuntu 24.04.4)

