### PR TITLE
Fix missing standard library headers for independent compilation (#184)

### DIFF
--- a/include/convex_bodies/correlation_matrices/corre_matrix.hpp
+++ b/include/convex_bodies/correlation_matrices/corre_matrix.hpp
@@ -10,6 +10,9 @@
 #ifndef VOLESTI_CONVEX_BODIES_CORRELATION_MATRICES_CORRE_MATRIX_HPP
 #define VOLESTI_CONVEX_BODIES_CORRELATION_MATRICES_CORRE_MATRIX_HPP
 
+#include <ostream>
+#include <iostream>
+
 /// This class handles the PointType used by CorreSpectra_MT class.
 /// Every point is a correlation matrix and only the lower triangular part is stored.
 /// @tparam NT Number Type

--- a/include/optimization/sliding_window.hpp
+++ b/include/optimization/sliding_window.hpp
@@ -10,7 +10,7 @@
 #ifndef VOLESTI_SLIDING_WINDOW_HPP
 #define VOLESTI_SLIDING_WINDOW_HPP
 
-
+#include <list>
 /// Computes the relative error
 /// \tparam NT Numeric type
 /// \param[in] approx The approximated value

--- a/include/random_walks/boundary_cdhr_walk.hpp
+++ b/include/random_walks/boundary_cdhr_walk.hpp
@@ -9,7 +9,7 @@
 #define RANDOM_WALKS_BOUNDARY_CDHR_WALK_HPP
 
 #include "sampling/sphere.hpp"
-
+#include <cmath>
 // random directions hit-and-run walk with uniform target distribution
 // from boundary
 


### PR DESCRIPTION
Hi @vissarion and @elias ! I am a Math & CS undergraduate student from the University of Murcia, Spain, and I'm very interested in participating in GSoC this year, specifically for the Benchmark Polytope Import Suite project.

To get familiar with the codebase and the contribution workflow, I started working on Issue #184. I found that independent compilation fails for some headers due to missing standard library includes.

In this PR, I have added the missing includes to the following files:

    <iostream> and <ostream> to corre_matrix.hpp

    <list> to sliding_window.hpp

    <cmath> to boundary_cdhr_walk.hpp (as Vissarion suggested in the issue comments).

Looking forward to your feedback. Let me know if you need me to change anything!