### PR TITLE
Added inner_ball_example and GSoC26 prerequisite test results for Exclude Lpsolve project (easy + hard)

### DIFF
--- a/docs/gsoc26_test_result_omraj9545.md
+++ b/docs/gsoc26_test_result_omraj9545.md
@@ -1,0 +1,169 @@
+# GSoC26 Test Results - omraj9545
+
+**GitHub:** [https://github.com/omraj9545](https://github.com/omraj9545)
+
+## Environment
+- **OS:** Ubuntu 22.04 (WSL/Docker)
+- **Compiler:** `g++ 11.4.0`
+- **R:** `4.1.2`
+
+---
+
+## Easy Test: C++ interface + maximum ball + using existing functions
+
+### Build
+```bash
+cd test/build
+cmake ..
+make
+```
+
+### Run
+```bash
+./inner_ball_example
+```
+
+### Output
+```text
+radius = 1
+center = 0 0
+```
+**Result:** Computed maximum inner ball for unit square using C++ interface.
+
+---
+
+## Easy Test: R interface + maximum ball
+
+### Run
+```r
+library(volesti)
+
+P <- gen_cube(3, "H")
+ball_vec <- inner_ball(P)
+
+
+d <- ncol(P@A)
+
+center <- ball_vec[1:d]
+radius <- ball_vec[d + 1]
+
+print(center)
+print(radius)
+```
+
+### Output
+```text
+[1] 0 0 0
+[1] 1
+```
+**Result:** Maximum ball computed successfully in R interface.
+
+---
+
+## Hard Test: nloptr-based max-ball implementation using R interface
+
+### Implementation
+```r
+library(nloptr)
+
+max_ball_nloptr <- function(A, b, x0 = NULL,
+                            algorithm = "NLOPT_LN_COBYLA",
+                            xtol_rel = 1e-8, maxeval = 5000) {
+  A <- as.matrix(A)
+  b <- as.numeric(b)
+
+  m <- nrow(A)
+  n <- ncol(A)
+  stopifnot(length(b) == m)
+
+  row_norms <- sqrt(rowSums(A^2))
+
+  if (is.null(x0)) x0 <- c(rep(0, n), 0.1)
+  stopifnot(length(x0) == n + 1)
+
+  # scalar objective
+  eval_f <- function(z) {
+    -z[n + 1]  # minimize -r
+  }
+
+  # vector of inequalities g(z) <= 0
+  eval_g_ineq <- function(z) {
+    x <- z[1:n]
+    r <- z[n + 1]
+    c(as.vector(A %*% x + r * row_norms - b), -r)
+  }
+
+  res <- nloptr(
+    x0 = x0,
+    eval_f = eval_f,
+    eval_g_ineq = eval_g_ineq,
+    opts = list(
+      algorithm = algorithm,
+      xtol_rel = xtol_rel,
+      maxeval = maxeval,
+      print_level = 0
+    )
+  )
+
+  z <- res$solution
+  list(
+    center = z[1:n],
+    radius = z[n + 1],
+    objective = res$objective,
+    status = res$status,
+    message = res$message,
+    raw = res
+  )
+}
+
+A <- rbind(
+  c( 1, 0),
+  c(-1, 0),
+  c( 0, 1),
+  c( 0,-1)
+)
+b <- c(1,1,1,1)
+
+out <- max_ball_nloptr(A, b)
+
+out$center
+out$radius
+out$objective
+out$status
+out$message
+print(out$raw)
+
+cat("center:", signif(out$center, 6), "\n")
+cat("radius:", signif(out$radius, 10), "\n")
+```
+
+### Results & Output
+```text
+[1]  6.246424e-11 -6.572057e-10
+[1] 1
+[1] -1
+[1] 4
+[1] "NLOPT_XTOL_REACHED: Optimization stopped because xtol_rel or xtol_abs (above) was reached."
+
+Call:
+
+nloptr(x0 = x0, eval_f = eval_f, eval_g_ineq = eval_g_ineq, opts = list(algorithm = algorithm,
+    xtol_rel = xtol_rel, maxeval = maxeval, print_level = 0))
+
+
+Minimization using NLopt version 2.10.0
+
+NLopt solver status: 4 ( NLOPT_XTOL_REACHED: Optimization stopped because
+xtol_rel or xtol_abs (above) was reached. )
+
+Number of Iterations....: 82
+Termination conditions:  xtol_rel: 1e-08        maxeval: 5000
+Number of inequality constraints:  5
+Number of equality constraints:    0
+Optimal value of objective function:  -1.00000000043253
+Optimal value of controls: 6.246424e-11 -6.572057e-10 1
+
+
+center: 6.24642e-11 -6.57206e-10
+radius: 1
+```

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -188,6 +188,9 @@ add_definitions(${CMAKE_CXX_FLAGS} "-DMKL_ILP64")
 #add_definitions(${CXX_COVERAGE_COMPILE_FLAGS} "-lgslcblas")
 #add_definitions( "-O3 -lgsl -lm -ldl -lgslcblas" )
 
+add_executable(inner_ball_example inner_ball_example.cpp)
+target_link_libraries(inner_ball_example PUBLIC lp_solve)
+
 add_executable (new_volume_example new_volume_example.cpp)
 add_executable (benchmarks_sob benchmarks_sob.cpp)
 add_executable (benchmarks_cg benchmarks_cg.cpp)

--- a/test/inner_ball_example.cpp
+++ b/test/inner_ball_example.cpp
@@ -1,0 +1,31 @@
+#include "Eigen/Eigen"
+#include "cartesian_geom/cartesian_kernel.h"
+#include "convex_bodies/hpolytope.h"
+
+using NT = double;
+using MT = Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic>;
+using VT = Eigen::Matrix<NT, Eigen::Dynamic, 1>;
+using Kernel = Cartesian<NT>;
+using Point = typename Kernel::Point;
+using Polytope = HPolytope<Point>;
+
+int main() {
+    MT A(4,2);
+    VT b(4);
+
+    A <<  1,  0,
+         -1,  0,
+          0,  1,
+          0, -1;
+    b << 1, 1, 1, 1;   // unit square
+
+    Polytope P(2, A, b);
+
+    auto inner_ball = P.ComputeInnerBall();
+    Point c = inner_ball.first;
+    NT r = inner_ball.second;
+
+    std::cout << "radius = " << r << "\ncenter = ";
+    for (unsigned i = 0; i < P.dimension(); ++i) std::cout << c[i] << " ";
+    std::cout << "\n";
+}


### PR DESCRIPTION
This PR adds my GSoC26 prerequisite test work and supporting test artifacts.

### Files added/changed

- `docs/gsoc26_test_result_omraj9545.md` (new)
- `test/inner_ball_example.cpp` (new)
- `test/CMakeLists.txt` (modified)

## What is included

1. **Easy Test (C++ interface)**
   - Added `inner_ball_example.cpp` to compute maximum inner ball using existing Volesti functions.
   - Integrated executable target via `test/CMakeLists.txt`.
   - Verified output on unit square:
     - center = (0, 0)
     - radius = 1

2. **Easy Test (R interface)**
   - Report includes R-based max-ball computation using `inner_ball`.
   - Verified output for `gen_cube(3, "H")`:
     - center = (0, 0, 0)
     - radius = 1

3. **Hard Test**
   - Report includes `nloptr`-based implementation for maximum-ball computation in R.
   - Verified convergence and expected result for unit square:
     - center ≈ (0, 0)
     - radius ≈ 1

## Notes

- Environment details (OS/compiler/R version) are included.
- Reproducible commands, implementation code, and outputs are documented in:
  - `docs/gsoc26_test_result_omraj9545.md`