### PR TITLE
Add SimplexIntersectBall convex body and tests

### DIFF
--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -2,7 +2,6 @@
 #define SIMPLEXINTERSECTBALL_H
 
 #include <limits>
-#include <iostream>
 #include <cmath>
 #include <utility>
 #include <vector>
@@ -31,8 +30,7 @@ public:
     typedef Point                                             PointType;
     typedef typename Point::FT                                NT;
     typedef MT_type                                           MT;
-    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT;
-    typedef Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> DenseMT;
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT; 
 
         static NT pi()
     {
@@ -45,27 +43,20 @@ private:
     VT           b;   // vector b, such that A x <= b
     MT           V;   // simplex vertices, stored column-wise
     VT           x0;  // center of the unit ball
-    VT           Vnorms;
+
 
 public:
     SimplexIntersectBall() {}
 
     SimplexIntersectBall(unsigned int d_,
-                         MT const& A_,
-                         VT const& b_,
-                         MT const& V_,
-                         VT const& x0_)
-        : _d{d_}, A{A_}, b{b_}, V{V_}, x0{x0_}
+                     MT const& A_,
+                     VT const& b_,
+                     MT const& V_,
+                     VT const& x0_)
+    : _d{d_}, A{A_}, b{b_}, V{V_}, x0{x0_}
     {
-        Vnorms = V.colwise().norm();
-        Vnorms = Vnorms.cwiseProduct(Vnorms);
     }
 
-    // Copy constructor
-    SimplexIntersectBall(SimplexIntersectBall<Point, MT_type> const& p)
-        : _d{p._d}, A{p.A}, b{p.b}, V{p.V}, x0{p.x0}, Vnorms{p.Vnorms}
-    {
-    }
 
     // Return dimension
     unsigned int dimension() const
@@ -119,8 +110,6 @@ public:
     void set_vertices(MT const& V2)
     {
         V = V2;
-        Vnorms = V.colwise().norm();
-        Vnorms = Vnorms.cwiseProduct(Vnorms);
     }
 
     // Change ball center
@@ -621,7 +610,7 @@ public:
     }
 
 
-        // Compute all intersection roots of the great circle
+    // Compute all intersection roots of the great circle
     // x(lambda) = cos(lambda) * r + sin(lambda) * v
     // with the simplex boundary A x <= b.
     //

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -1,0 +1,769 @@
+#ifndef SIMPLEXINTERSECTBALL_H
+#define SIMPLEXINTERSECTBALL_H
+
+#include <limits>
+#include <iostream>
+#include <cmath>
+#include <utility>
+#include <Eigen/Eigen>
+
+/// This class represents the intersection of a simplex with the unit ball.
+/// The simplex is given in H-representation:
+///     A x <= b
+/// and the ball is:
+///     ||x - x0|| <= 1
+///
+/// Return convention for is_in:
+///     -1 : inside
+///      0 : outside
+///
+/// \tparam Point Point type used by volesti
+/// \tparam MT_type Matrix type for A
+template
+<
+    typename Point,
+    typename MT_type = Eigen::Matrix<typename Point::FT, Eigen::Dynamic, Eigen::Dynamic>
+>
+class SimplexIntersectBall {
+public:
+    typedef Point                                             PointType;
+    typedef typename Point::FT                                NT;
+    typedef MT_type                                           MT;
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT;
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> DenseMT;
+
+private:
+    unsigned int _d;  // dimension
+    MT           A;   // matrix A
+    VT           b;   // vector b, such that A x <= b
+    MT           V;   // simplex vertices, stored column-wise
+    VT           x0;  // center of the unit ball
+    VT           Vnorms;
+
+public:
+    SimplexIntersectBall() {}
+
+    SimplexIntersectBall(unsigned int d_,
+                         MT const& A_,
+                         VT const& b_,
+                         MT const& V_,
+                         VT const& x0_)
+        : _d{d_}, A{A_}, b{b_}, V{V_}, x0{x0_}
+    {
+        Vnorms = V.colwise().norm();
+        Vnorms = Vnorms.cwiseProduct(Vnorms);
+    }
+
+    // Copy constructor
+    SimplexIntersectBall(SimplexIntersectBall<Point, MT_type> const& p)
+        : _d{p._d}, A{p.A}, b{p.b}, V{p.V}, x0{p.x0}, Vnorms{p.Vnorms}
+    {
+    }
+
+    // Return dimension
+    unsigned int dimension() const
+    {
+        return _d;
+    }
+
+    // Return number of facets / hyperplanes
+    int num_of_hyperplanes() const
+    {
+        return A.rows();
+    }
+
+    // Return matrix A
+    MT get_mat() const
+    {
+        return A;
+    }
+
+    // Return vector b
+    VT get_vec() const
+    {
+        return b;
+    }
+
+    // Return simplex vertices
+    MT get_vertices() const
+    {
+        return V;
+    }
+
+    // Return center of the unit ball
+    VT get_center() const
+    {
+        return x0;
+    }
+
+    // Change matrix A
+    void set_mat(MT const& A2)
+    {
+        A = A2;
+    }
+
+    // Change vector b
+    void set_vec(VT const& b2)
+    {
+        b = b2;
+    }
+
+    // Change simplex vertices
+    void set_vertices(MT const& V2)
+    {
+        V = V2;
+        Vnorms = V.colwise().norm();
+        Vnorms = Vnorms.cwiseProduct(Vnorms);
+    }
+
+    // Change ball center
+    void set_center(VT const& x02)
+    {
+        x0 = x02;
+    }
+
+    // Check if Point p lies in the simplex-ball intersection:
+    //     A p <= b
+    //     ||p - x0|| <= 1
+    int is_in(Point const& p, NT tol = NT(0)) const
+    {
+        VT p_vec = p.getCoefficients();
+
+        // Check ball condition
+        VT diff = p_vec - x0;
+        if (diff.squaredNorm() > NT(1) + tol) {
+            return 0;
+        }
+
+        // Check simplex inequalities A p <= b
+        VT temp = b - A * p_vec;
+        const NT* Ax_b_data = temp.data();
+
+        for (int i = 0; i < A.rows(); i++) {
+            if ((*Ax_b_data) < NT(-tol)) {
+                return 0;
+            }
+            Ax_b_data++;
+        }
+
+        return -1;
+    }
+
+    int is_in_optimized(Point const& p,
+                    VT& Ar,
+                    VT& Av,
+                    NT const& lambda_prev,
+                    NT tol = NT(0)) const
+    {
+        VT p_vec = p.getCoefficients();
+
+        // Ball membership check.
+        VT diff = p_vec - x0;
+        if (diff.squaredNorm() > NT(1) + tol) return 0;
+
+        // Update cached A*x along the great-circle rotation:
+        // x(lambda) = cos(lambda) * r + sin(lambda) * v.
+        //
+        // Here Ar stores A*r and Av stores A*v from the previous step.
+        Ar.noalias() = std::cos(lambda_prev) * Ar + std::sin(lambda_prev) * Av;
+
+        VT temp = b - Ar;
+        const NT* Ax_b_data = temp.data();
+
+        for (int i = 0; i < A.rows(); i++) {
+            if ((*Ax_b_data) < NT(-tol)) return 0;
+            Ax_b_data++;
+        }
+
+        return -1;
+    }
+
+
+    // Compute intersection parameters of the line r + lambda * v
+    // with the simplex A x <= b.
+    //
+    // Returns:
+    //   first  = smallest positive lambda
+    //   second = largest negative lambda
+    std::pair<NT, NT> line_intersect(Point const& r, Point const& v) const
+    {
+        NT lambda = 0;
+        NT min_plus  = std::numeric_limits<NT>::max();
+        NT max_minus = std::numeric_limits<NT>::lowest();
+
+        VT sum_nom;
+        VT sum_denom;
+
+        int m = num_of_hyperplanes();
+
+        sum_nom.noalias() = b - A * r.getCoefficients();
+        sum_denom.noalias() = A * v.getCoefficients();
+
+        NT* sum_nom_data = sum_nom.data();
+        NT* sum_denom_data = sum_denom.data();
+
+        for (int i = 0; i < m; i++) {
+            if (*sum_denom_data != NT(0)) {
+                lambda = *sum_nom_data / *sum_denom_data;
+
+                if (lambda < min_plus && lambda > NT(0)) {
+                    min_plus = lambda;
+                }
+
+                if (lambda > max_minus && lambda < NT(0)) {
+                    max_minus = lambda;
+                }
+            }
+
+            sum_nom_data++;
+            sum_denom_data++;
+        }
+
+        return std::make_pair(min_plus, max_minus);
+    }
+
+    // Optimized version of line_intersect.
+    // It also computes and returns:
+    //     Ar = A * r
+    //     Av = A * v
+    //
+    // If pos = false:
+    //   returns (min positive lambda, max negative lambda)
+    //
+    // If pos = true:
+    //   returns (min positive lambda, facet index)
+    std::pair<NT, NT> line_intersect(Point const& r,
+                                     Point const& v,
+                                     VT& Ar,
+                                     VT& Av,
+                                     bool pos = false) const
+    {
+        NT lambda = 0;
+        NT min_plus  = std::numeric_limits<NT>::max();
+        NT max_minus = std::numeric_limits<NT>::lowest();
+
+        VT sum_nom;
+        int m = num_of_hyperplanes();
+        int facet = -1;
+
+        Ar.noalias() = A * r.getCoefficients();
+        sum_nom.noalias() = b - Ar;
+        Av.noalias() = A * v.getCoefficients();
+
+        NT* Av_data = Av.data();
+        NT* sum_nom_data = sum_nom.data();
+
+        for (int i = 0; i < m; i++) {
+            if (*Av_data != NT(0)) {
+                lambda = *sum_nom_data / *Av_data;
+
+                if (lambda < min_plus && lambda > NT(0)) {
+                    min_plus = lambda;
+                    if (pos) {
+                        facet = i;
+                    }
+                } else if (lambda > max_minus && lambda < NT(0)) {
+                    max_minus = lambda;
+                }
+            }
+
+            Av_data++;
+            sum_nom_data++;
+        }
+
+        if (pos) {
+            return std::make_pair(min_plus, facet);
+        }
+
+        return std::make_pair(min_plus, max_minus);
+    }
+
+    // Optimized line_intersect version using the previous lambda.
+    // Ar is updated as:
+    //     Ar <- Ar + lambda_prev * Av
+    //
+    // Then Av is recomputed as:
+    //     Av <- A * v
+    std::pair<NT, NT> line_intersect(Point const& r,
+                                     Point const& v,
+                                     VT& Ar,
+                                     VT& Av,
+                                     NT const& lambda_prev,
+                                     bool pos = false) const
+    {   
+        (void)r;  
+        NT lambda = 0;
+        NT min_plus  = std::numeric_limits<NT>::max();
+        NT max_minus = std::numeric_limits<NT>::lowest();
+
+        VT sum_nom;
+        int m = num_of_hyperplanes();
+        int facet = -1;
+
+        Ar.noalias() += lambda_prev * Av;
+        sum_nom.noalias() = b - Ar;
+        Av.noalias() = A * v.getCoefficients();
+
+        NT* sum_nom_data = sum_nom.data();
+        NT* Av_data = Av.data();
+
+        for (int i = 0; i < m; i++) {
+            if (*Av_data != NT(0)) {
+                lambda = *sum_nom_data / *Av_data;
+
+                if (lambda < min_plus && lambda > NT(0)) {
+                    min_plus = lambda;
+                    if (pos) {
+                        facet = i;
+                    }
+                } else if (lambda > max_minus && lambda < NT(0)) {
+                    max_minus = lambda;
+                }
+            }
+
+            Av_data++;
+            sum_nom_data++;
+        }
+
+        if (pos) {
+            return std::make_pair(min_plus, facet);
+        }
+
+        return std::make_pair(min_plus, max_minus);
+    }
+
+        // Compute intersection angles of the great circle
+    // x(lambda) = cos(lambda) * r + sin(lambda) * v
+    // with the simplex boundary A x <= b.
+    //
+    // Input:
+    //   Ar = A * r
+    //   Av = A * v
+    //
+    // Returns:
+    //   first  = smallest positive angle lambda
+    //   second = largest negative angle lambda
+    std::pair<NT, NT> compute_intersections(VT& Ar, VT& Av) const
+    {
+        NT D;
+        NT C1;
+        NT C2;
+        NT eval;
+
+        NT max_root = std::numeric_limits<NT>::lowest();
+        NT min_root = std::numeric_limits<NT>::max();
+
+        NT min_plus  = std::numeric_limits<NT>::max();
+        NT max_minus = std::numeric_limits<NT>::lowest();
+
+        int m = num_of_hyperplanes();
+
+        bool set_negative_root = false;
+        bool set_positive_root = false;
+        bool pos_D = false;
+
+        NT* Av_data = Av.data();
+        NT* Ar_data = Ar.data();
+        const NT* b_data = b.data();
+
+        for (int i = 0; i < m; i++) {
+            D = (*Ar_data) * (*Ar_data)
+              + (*Av_data) * (*Av_data)
+              - (*b_data) * (*b_data);
+
+            if (D > NT(0)) {
+                pos_D = true;
+
+                NT denom = (*Ar_data) * (*Ar_data)
+                         + (*Av_data) * (*Av_data);
+
+                C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * std::sqrt(D))) / denom);
+                C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * std::sqrt(D))) / denom);
+
+                eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C1 = M_PI - C1;
+                }
+
+                if (C1 < min_plus && C1 > NT(0)) {
+                    min_plus = C1;
+                    set_positive_root = true;
+                } else if (C1 > max_minus && C1 < NT(0)) {
+                    max_minus = C1;
+                    set_negative_root = true;
+                }
+
+                if (C1 > max_root && C1 < NT(2) * M_PI) {
+                    max_root = C1;
+                }
+
+                if ((C1 < min_root) && (C1 > (-NT(2) * M_PI))) {
+                    min_root = C1;
+                }
+
+                eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C2 = M_PI - C2;
+                }
+
+                if (C2 < min_plus && C2 > NT(0)) {
+                    min_plus = C2;
+                    set_positive_root = true;
+                } else if (C2 > max_minus && C2 < NT(0)) {
+                    max_minus = C2;
+                    set_negative_root = true;
+                }
+
+                if (C2 > max_root && C2 < NT(2) * M_PI) {
+                    max_root = C2;
+                }
+
+                if (C2 < min_root && C2 > (-NT(2) * M_PI)) {
+                    min_root = C2;
+                }
+            }
+
+            Av_data++;
+            Ar_data++;
+            b_data++;
+        }
+
+        if (!set_negative_root) {
+            if (pos_D) {
+                max_minus = max_root - NT(2) * M_PI;
+            } else {
+                max_minus = NT(0);
+            }
+        }
+
+        if (!set_positive_root) {
+            if (pos_D) {
+                min_plus = min_root + NT(2) * M_PI;
+            } else {
+                min_plus = NT(2) * M_PI;
+            }
+        }
+
+        return std::make_pair(min_plus, max_minus);
+    }
+
+    // Great-circle intersection.
+    // Computes Ar = A*r and Av = A*v, then calls compute_intersections.
+    std::pair<NT, NT> gc_intersect(Point const& r,
+                                   Point const& v,
+                                   VT& Ar,
+                                   VT& Av) const
+    {
+        Ar.noalias() = A * r.getCoefficients();
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections(Ar, Av);
+    }
+
+    // Optimized great-circle intersection using previous lambda.
+    std::pair<NT, NT> gc_intersect(Point const& r,
+                                   Point const& v,
+                                   VT& Ar,
+                                   VT& Av,
+                                   NT const& lambda_prev) const
+    {
+        (void)r;
+
+        Ar.noalias() = std::cos(lambda_prev) * Ar + std::sin(lambda_prev) * Av;
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections(Ar, Av);
+    }
+
+    // Great-circle intersection assuming Ar is already up to date.
+    std::pair<NT, NT> gc_intersect_optimized(Point const& r,
+                                             Point const& v,
+                                             VT& Ar,
+                                             VT& Av,
+                                             NT const& lambda_prev) const
+    {
+        (void)r;
+        (void)lambda_prev;
+
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections(Ar, Av);
+    }
+
+    // Compute the first positive intersection angle of the great circle
+    // x(lambda) = cos(lambda) * r + sin(lambda) * v
+    // with the simplex boundary A x <= b.
+    //
+    // Input:
+    //   Ar = A * r
+    //   Av = A * v
+    //
+    // Returns:
+    //   first  = smallest positive angle lambda
+    //   second = index of the facet hit
+    std::pair<NT, int> compute_intersections_positive(VT const& Ar, VT const& Av) const
+    {
+        NT D;
+        NT C1;
+        NT C2;
+        NT eval;
+        NT min_root = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
+
+        int m = num_of_hyperplanes();
+        int facet = -1;
+        int facet_min = -1;
+
+        bool set_positive_root = false;
+        bool pos_D = false;
+
+        const NT* Av_data = Av.data();
+        const NT* Ar_data = Ar.data();
+        const NT* b_data = b.data();
+
+        for (int i = 0; i < m; i++) {
+            D = (*Ar_data) * (*Ar_data)
+              + (*Av_data) * (*Av_data)
+              - (*b_data) * (*b_data);
+
+            if (D > NT(0)) {
+                pos_D = true;
+
+                NT denom = (*Ar_data) * (*Ar_data)
+                         + (*Av_data) * (*Av_data);
+
+                C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * std::sqrt(D))) / denom);
+                C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * std::sqrt(D))) / denom);
+
+                eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C1 = M_PI - C1;
+                }
+
+                if (C1 < min_plus && C1 > NT(0)) {
+                    min_plus = C1;
+                    set_positive_root = true;
+                    facet = i;
+                }
+
+                if ((C1 < min_root) && (C1 > (-NT(2) * M_PI))) {
+                    min_root = C1;
+                    facet_min = i;
+                }
+
+                eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C2 = M_PI - C2;
+                }
+
+                if (C2 < min_plus && C2 > NT(0)) {
+                    min_plus = C2;
+                    set_positive_root = true;
+                    facet = i;
+                }
+
+                if (C2 < min_root && C2 > (-NT(2) * M_PI)) {
+                    min_root = C2;
+                    facet_min = i;
+                }
+            }
+
+            Av_data++;
+            Ar_data++;
+            b_data++;
+        }
+
+        if (!set_positive_root) {
+            if (pos_D) {
+                min_plus = min_root + NT(2) * M_PI;
+                facet = facet_min;
+            } else {
+                min_plus = NT(2) * M_PI;
+            }
+        }
+
+        return std::make_pair(min_plus, facet);
+    }
+
+    // Great-circle first positive intersection.
+    // Computes Ar = A*r and Av = A*v, then calls compute_intersections_positive.
+    std::pair<NT, int> gc_intersect_positive(Point const& r,
+                                             Point const& v,
+                                             VT& Ar,
+                                             VT& Av) const
+    {
+        Ar.noalias() = A * r.getCoefficients();
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections_positive(Ar, Av);
+    }
+
+    // Optimized great-circle first positive intersection using previous lambda.
+    std::pair<NT, int> gc_intersect_positive(Point const& r,
+                                             Point const& v,
+                                             VT& Ar,
+                                             VT& Av,
+                                             NT const& lambda_prev) const
+    {
+        (void)r;
+
+        Ar.noalias() = std::cos(lambda_prev) * Ar + std::sin(lambda_prev) * Av;
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections_positive(Ar, Av);
+    }
+
+
+        // Compute all intersection roots of the great circle
+    // x(lambda) = cos(lambda) * r + sin(lambda) * v
+    // with the simplex boundary A x <= b.
+    //
+    // Returns:
+    //   first  = negative roots in (-pi, 0)
+    //   second = positive roots in (0, pi)
+    std::pair<VT, VT> compute_intersections_all_roots(VT& Ar, VT& Av) const
+    {
+        std::vector<NT> neg_roots;
+        std::vector<NT> pos_roots;
+
+        int m = num_of_hyperplanes();
+
+        NT* Av_data = Av.data();
+        NT* Ar_data = Ar.data();
+        const NT* b_data = b.data();
+
+        for (int i = 0; i < m; i++) {
+            NT denom = (*Ar_data) * (*Ar_data) + (*Av_data) * (*Av_data);
+            NT D = denom - (*b_data) * (*b_data);
+
+            if (D > NT(0)) {
+                NT sqrtD = std::sqrt(D);
+
+                NT C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * sqrtD)) / denom);
+                NT C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * sqrtD)) / denom);
+
+                NT eval = (*Ar_data) * std::cos(C1)
+                        + (*Av_data) * std::sin(C1)
+                        - (*b_data);
+
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C1 = M_PI - C1;
+                }
+
+                if (C1 > M_PI) {
+                    C1 -= NT(2) * M_PI;
+                } else if (C1 < -M_PI) {
+                    C1 += NT(2) * M_PI;
+                }
+
+                if ((C1 > -M_PI) && (C1 < NT(0))) {
+                    neg_roots.push_back(C1);
+                } else if ((C1 < M_PI) && (C1 > NT(0))) {
+                    pos_roots.push_back(C1);
+                }
+
+                eval = (*Ar_data) * std::cos(C2)
+                     + (*Av_data) * std::sin(C2)
+                     - (*b_data);
+
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C2 = M_PI - C2;
+                }
+
+                if (C2 > M_PI) {
+                    C2 -= NT(2) * M_PI;
+                } else if (C2 < -M_PI) {
+                    C2 += NT(2) * M_PI;
+                }
+
+                if ((C2 > -M_PI) && (C2 < NT(0))) {
+                    neg_roots.push_back(C2);
+                } else if ((C2 < M_PI) && (C2 > NT(0))) {
+                    pos_roots.push_back(C2);
+                }
+            }
+
+            Av_data++;
+            Ar_data++;
+            b_data++;
+        }
+
+        std::sort(neg_roots.begin(), neg_roots.end());
+        std::sort(pos_roots.begin(), pos_roots.end());
+
+        VT neg_roots_vec(neg_roots.size());
+        for (unsigned int i = 0; i < neg_roots.size(); i++) {
+            neg_roots_vec(i) = neg_roots[i];
+        }
+
+        VT pos_roots_vec(pos_roots.size());
+        for (unsigned int i = 0; i < pos_roots.size(); i++) {
+            pos_roots_vec(i) = pos_roots[i];
+        }
+
+        return std::make_pair(neg_roots_vec, pos_roots_vec);
+    }
+
+    // Great-circle all-roots intersection.
+    std::pair<VT, VT> gc_intersect_all_roots(Point const& r,
+                                             Point const& v,
+                                             VT& Ar,
+                                             VT& Av) const
+    {
+        Ar.noalias() = A * r.getCoefficients();
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections_all_roots(Ar, Av);
+    }
+
+    // Optimized great-circle all-roots intersection using previous lambda.
+    std::pair<VT, VT> gc_intersect_all_roots(Point const& r,
+                                             Point const& v,
+                                             VT& Ar,
+                                             VT& Av,
+                                             NT const& lambda_prev) const
+    {
+        (void)r;
+
+        Ar.noalias() = std::cos(lambda_prev) * Ar + std::sin(lambda_prev) * Av;
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections_all_roots(Ar, Av);
+    }
+
+    // Apply linear transformation T to the simplex inequalities.
+    // If the point transformation is x <- T^{-1} x,
+    // then the H-representation matrix changes as A <- A * T.
+    void linear_transformIt(MT const& T)
+    {
+        A = A * T;
+    }
+
+    // Shift the simplex by a vector c.
+    // For A x <= b, after shifting x <- x + c,
+    // the right-hand side changes as b <- b - A*c.
+    void shift(VT const& c)
+    {
+        b -= A * c;
+    }
+
+    // Reflect tangent direction v at point p on the sphere
+    // against the facet indexed by facet.
+    //
+    // p_p is the tangent-space projector:
+    //     p_p = I - p p^T
+    void compute_reflection(VT& v,
+                            VT const& p,
+                            MT const& p_p,
+                            int const& facet) const
+    {
+        (void)p;
+
+        VT u = p_p * A.row(facet).transpose();
+        u *= (NT(1) / u.norm());
+
+        v += -NT(2) * v.dot(u) * u;
+    }
+
+};
+#endif

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <cmath>
 #include <utility>
+#include <vector>
+#include <algorithm>
 #include <Eigen/Eigen>
 
 /// This class represents the intersection of a simplex with the unit ball.
@@ -131,9 +133,8 @@ public:
 
         // Check ball condition
         VT diff = p_vec - x0;
-        if (diff.squaredNorm() > NT(1) + tol) {
-            return 0;
-        }
+        NT radius_tol = NT(1) + tol;
+        if (diff.squaredNorm() > radius_tol * radius_tol) return 0;
 
         // Check simplex inequalities A p <= b
         VT temp = b - A * p_vec;
@@ -159,7 +160,8 @@ public:
 
         // Ball membership check.
         VT diff = p_vec - x0;
-        if (diff.squaredNorm() > NT(1) + tol) return 0;
+        NT radius_tol = NT(1) + tol;
+        if (diff.squaredNorm() > radius_tol * radius_tol) return 0;
 
         // Update cached A*x along the great-circle rotation:
         // x(lambda) = cos(lambda) * r + sin(lambda) * v.

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -151,10 +151,10 @@ public:
     }
 
     int is_in_optimized(Point const& p,
-                    VT& Ar,
-                    VT& Av,
-                    NT const& lambda_prev,
-                    NT tol = NT(0)) const
+                         VT& Ar,
+                         VT& Av,
+                         NT const& lambda_prev,
+                         NT tol = NT(0)) const
     {
         VT p_vec = p.getCoefficients();
 
@@ -334,7 +334,7 @@ public:
         return std::make_pair(min_plus, max_minus);
     }
 
-        // Compute intersection angles of the great circle
+    // Compute intersection angles of the great circle
     // x(lambda) = cos(lambda) * r + sin(lambda) * v
     // with the simplex boundary A x <= b.
     //

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -36,11 +36,6 @@ public:
         return std::acos(NT(-1));
     }
 
-    static NT trig_tol()
-    {
-        return NT(1e-05);
-    }
-
 private:
     unsigned int _d; // dimension
     MT A;            // matrix A
@@ -48,36 +43,39 @@ private:
     MT V;            // simplex vertices, stored column-wise
     VT x0;           // center of the unit ball
 
-    bool compute_facet_roots(NT const &Ar_i,
-                             NT const &Av_i,
-                             NT const &b_i,
-                             NT &C1,
-                             NT &C2) const
+    bool compute_facet_roots(NT const& Ar_i,
+                            NT const& Av_i,
+                            NT const& b_i,
+                            NT& C1,
+                            NT& C2) const
     {
-        NT denom = Ar_i * Ar_i + Av_i * Av_i;
-        NT D = denom - b_i * b_i;
+        NT const denom =
+            Ar_i * Ar_i + Av_i * Av_i;
+
+        NT const D =
+            denom - b_i * b_i;
 
         if (D <= NT(0))
         {
             return false;
         }
 
-        NT sqrtD = std::sqrt(D);
+        NT const radius =
+            std::sqrt(denom);
 
-        C1 = std::asin((Av_i * b_i + Ar_i * sqrtD) / denom);
-        C2 = std::asin((Av_i * b_i - Ar_i * sqrtD) / denom);
+        NT const phase =
+            std::atan2(Av_i, Ar_i);
 
-        NT eval = Ar_i * std::cos(C1) + Av_i * std::sin(C1) - b_i;
-        if (!(eval > -trig_tol() && eval < trig_tol()))
-        {
-            C1 = pi() - C1;
-        }
+        NT const cosine =
+            std::max(
+                NT(-1),
+                std::min(NT(1), b_i / radius));
 
-        eval = Ar_i * std::cos(C2) + Av_i * std::sin(C2) - b_i;
-        if (!(eval > -trig_tol() && eval < trig_tol()))
-        {
-            C2 = pi() - C2;
-        }
+        NT const offset =
+            std::acos(cosine);
+
+        C1 = phase + offset;
+        C2 = phase - offset;
 
         return true;
     }
@@ -568,37 +566,72 @@ public:
         bool set_positive_root = false;
         bool pos_D = false;
 
+        NT const root_tolerance =
+            NT(64) * std::numeric_limits<NT>::epsilon();
+
         const NT *Av_data = Av.data();
         const NT *Ar_data = Ar.data();
         const NT *b_data = b.data();
 
         for (int i = 0; i < m; i++)
         {
-            if (compute_facet_roots(*Ar_data, *Av_data, *b_data, C1, C2))
+            NT const scale =
+                std::max(
+                    NT(1),
+                    std::max(
+                        std::abs(*Ar_data),
+                        std::max(
+                            std::abs(*Av_data),
+                            std::abs(*b_data))));
+
+            NT const equation_tolerance =
+                NT(128) *
+                std::numeric_limits<NT>::epsilon() *
+                scale;
+
+            // If the current point lies on this facet and the tangent
+            // direction points outside, the collision is immediate.
+            if (std::abs(*Ar_data - *b_data) <=
+                    equation_tolerance &&
+                *Av_data > equation_tolerance)
+            {
+                return std::make_pair(NT(0), i);
+            }
+
+            if (compute_facet_roots(
+                    *Ar_data,
+                    *Av_data,
+                    *b_data,
+                    C1,
+                    C2))
             {
                 pos_D = true;
 
-                if (C1 < min_plus && C1 > NT(0))
+                if (C1 < min_plus &&
+                    C1 > root_tolerance)
                 {
                     min_plus = C1;
                     set_positive_root = true;
                     facet = i;
                 }
 
-                if ((C1 < min_root) && (C1 > (-NT(2) * pi())))
+                if ((C1 < min_root) &&
+                    (C1 > (-NT(2) * pi())))
                 {
                     min_root = C1;
                     facet_min = i;
                 }
 
-                if (C2 < min_plus && C2 > NT(0))
+                if (C2 < min_plus &&
+                    C2 > root_tolerance)
                 {
                     min_plus = C2;
                     set_positive_root = true;
                     facet = i;
                 }
 
-                if (C2 < min_root && C2 > (-NT(2) * pi()))
+                if (C2 < min_root &&
+                    C2 > (-NT(2) * pi()))
                 {
                     min_root = C2;
                     facet_min = i;

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -36,6 +36,11 @@ public:
         return std::acos(NT(-1));
     }
 
+    static NT trig_tol()
+    {
+        return NT(1e-05);
+    }
+
 private:
     unsigned int _d; // dimension
     MT A;            // matrix A
@@ -63,13 +68,13 @@ private:
         C2 = std::asin((Av_i * b_i - Ar_i * sqrtD) / denom);
 
         NT eval = Ar_i * std::cos(C1) + Av_i * std::sin(C1) - b_i;
-        if (!(eval > -NT(1e-05) && eval < NT(1e-05)))
+        if (!(eval > -trig_tol() && eval < trig_tol()))
         {
             C1 = pi() - C1;
         }
 
         eval = Ar_i * std::cos(C2) + Av_i * std::sin(C2) - b_i;
-        if (!(eval > -NT(1e-05) && eval < NT(1e-05)))
+        if (!(eval > -trig_tol() && eval < trig_tol()))
         {
             C2 = pi() - C2;
         }

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -34,6 +34,11 @@ public:
     typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT;
     typedef Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> DenseMT;
 
+        static NT pi()
+    {
+        return std::acos(NT(-1));
+    }
+
 private:
     unsigned int _d;  // dimension
     MT           A;   // matrix A
@@ -384,7 +389,7 @@ public:
 
                 eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = M_PI - C1;
+                    C1 = pi() - C1;
                 }
 
                 if (C1 < min_plus && C1 > NT(0)) {
@@ -395,17 +400,17 @@ public:
                     set_negative_root = true;
                 }
 
-                if (C1 > max_root && C1 < NT(2) * M_PI) {
+                if (C1 > max_root && C1 < NT(2) * pi()) {
                     max_root = C1;
                 }
 
-                if ((C1 < min_root) && (C1 > (-NT(2) * M_PI))) {
+                if ((C1 < min_root) && (C1 > (-NT(2) * pi()))) {
                     min_root = C1;
                 }
 
                 eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = M_PI - C2;
+                    C2 = pi() - C2;
                 }
 
                 if (C2 < min_plus && C2 > NT(0)) {
@@ -416,11 +421,11 @@ public:
                     set_negative_root = true;
                 }
 
-                if (C2 > max_root && C2 < NT(2) * M_PI) {
+                if (C2 > max_root && C2 < NT(2) * pi()) {
                     max_root = C2;
                 }
 
-                if (C2 < min_root && C2 > (-NT(2) * M_PI)) {
+                if (C2 < min_root && C2 > (-NT(2) * pi())) {
                     min_root = C2;
                 }
             }
@@ -432,7 +437,7 @@ public:
 
         if (!set_negative_root) {
             if (pos_D) {
-                max_minus = max_root - NT(2) * M_PI;
+                max_minus = max_root - NT(2) * pi();
             } else {
                 max_minus = NT(0);
             }
@@ -440,9 +445,9 @@ public:
 
         if (!set_positive_root) {
             if (pos_D) {
-                min_plus = min_root + NT(2) * M_PI;
+                min_plus = min_root + NT(2) * pi();
             } else {
-                min_plus = NT(2) * M_PI;
+                min_plus = NT(2) * pi();
             }
         }
 
@@ -539,7 +544,7 @@ public:
 
                 eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = M_PI - C1;
+                    C1 = pi() - C1;
                 }
 
                 if (C1 < min_plus && C1 > NT(0)) {
@@ -548,14 +553,14 @@ public:
                     facet = i;
                 }
 
-                if ((C1 < min_root) && (C1 > (-NT(2) * M_PI))) {
+                if ((C1 < min_root) && (C1 > (-NT(2) * pi()))) {
                     min_root = C1;
                     facet_min = i;
                 }
 
                 eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = M_PI - C2;
+                    C2 = pi() - C2;
                 }
 
                 if (C2 < min_plus && C2 > NT(0)) {
@@ -564,7 +569,7 @@ public:
                     facet = i;
                 }
 
-                if (C2 < min_root && C2 > (-NT(2) * M_PI)) {
+                if (C2 < min_root && C2 > (-NT(2) * pi())) {
                     min_root = C2;
                     facet_min = i;
                 }
@@ -577,10 +582,10 @@ public:
 
         if (!set_positive_root) {
             if (pos_D) {
-                min_plus = min_root + NT(2) * M_PI;
+                min_plus = min_root + NT(2) * pi();
                 facet = facet_min;
             } else {
-                min_plus = NT(2) * M_PI;
+                min_plus = NT(2) * pi();
             }
         }
 
@@ -649,18 +654,18 @@ public:
                         - (*b_data);
 
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = M_PI - C1;
+                    C1 = pi() - C1;
                 }
 
-                if (C1 > M_PI) {
-                    C1 -= NT(2) * M_PI;
-                } else if (C1 < -M_PI) {
-                    C1 += NT(2) * M_PI;
+                if (C1 > pi()) {
+                    C1 -= NT(2) * pi();
+                } else if (C1 < -pi()) {
+                    C1 += NT(2) * pi();
                 }
 
-                if ((C1 > -M_PI) && (C1 < NT(0))) {
+                if ((C1 > -pi()) && (C1 < NT(0))) {
                     neg_roots.push_back(C1);
-                } else if ((C1 < M_PI) && (C1 > NT(0))) {
+                } else if ((C1 < pi()) && (C1 > NT(0))) {
                     pos_roots.push_back(C1);
                 }
 
@@ -669,18 +674,18 @@ public:
                      - (*b_data);
 
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = M_PI - C2;
+                    C2 = pi() - C2;
                 }
 
-                if (C2 > M_PI) {
-                    C2 -= NT(2) * M_PI;
-                } else if (C2 < -M_PI) {
-                    C2 += NT(2) * M_PI;
+                if (C2 > pi()) {
+                    C2 -= NT(2) * pi();
+                } else if (C2 < -pi()) {
+                    C2 += NT(2) * pi();
                 }
 
-                if ((C2 > -M_PI) && (C2 < NT(0))) {
+                if ((C2 > -pi()) && (C2 < NT(0))) {
                     neg_roots.push_back(C2);
-                } else if ((C2 < M_PI) && (C2 > NT(0))) {
+                } else if ((C2 < pi()) && (C2 > NT(0))) {
                     pos_roots.push_back(C2);
                 }
             }

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -20,43 +20,74 @@
 ///
 /// \tparam Point Point type used by volesti
 /// \tparam MT_type Matrix type for A
-template
-<
+template <
     typename Point,
-    typename MT_type = Eigen::Matrix<typename Point::FT, Eigen::Dynamic, Eigen::Dynamic>
->
-class SimplexIntersectBall {
+    typename MT_type = Eigen::Matrix<typename Point::FT, Eigen::Dynamic, Eigen::Dynamic>>
+class SimplexIntersectBall
+{
 public:
-    typedef Point                                             PointType;
-    typedef typename Point::FT                                NT;
-    typedef MT_type                                           MT;
-    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT; 
+    typedef Point PointType;
+    typedef typename Point::FT NT;
+    typedef MT_type MT;
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
 
-        static NT pi()
+    static NT pi()
     {
         return std::acos(NT(-1));
     }
 
 private:
-    unsigned int _d;  // dimension
-    MT           A;   // matrix A
-    VT           b;   // vector b, such that A x <= b
-    MT           V;   // simplex vertices, stored column-wise
-    VT           x0;  // center of the unit ball
+    unsigned int _d; // dimension
+    MT A;            // matrix A
+    VT b;            // vector b, such that A x <= b
+    MT V;            // simplex vertices, stored column-wise
+    VT x0;           // center of the unit ball
 
+    bool compute_facet_roots(NT const &Ar_i,
+                             NT const &Av_i,
+                             NT const &b_i,
+                             NT &C1,
+                             NT &C2) const
+    {
+        NT denom = Ar_i * Ar_i + Av_i * Av_i;
+        NT D = denom - b_i * b_i;
+
+        if (D <= NT(0))
+        {
+            return false;
+        }
+
+        NT sqrtD = std::sqrt(D);
+
+        C1 = std::asin((Av_i * b_i + Ar_i * sqrtD) / denom);
+        C2 = std::asin((Av_i * b_i - Ar_i * sqrtD) / denom);
+
+        NT eval = Ar_i * std::cos(C1) + Av_i * std::sin(C1) - b_i;
+        if (!(eval > -NT(1e-05) && eval < NT(1e-05)))
+        {
+            C1 = pi() - C1;
+        }
+
+        eval = Ar_i * std::cos(C2) + Av_i * std::sin(C2) - b_i;
+        if (!(eval > -NT(1e-05) && eval < NT(1e-05)))
+        {
+            C2 = pi() - C2;
+        }
+
+        return true;
+    }
 
 public:
     SimplexIntersectBall() {}
 
     SimplexIntersectBall(unsigned int d_,
-                     MT const& A_,
-                     VT const& b_,
-                     MT const& V_,
-                     VT const& x0_)
-    : _d{d_}, A{A_}, b{b_}, V{V_}, x0{x0_}
+                         MT const &A_,
+                         VT const &b_,
+                         MT const &V_,
+                         VT const &x0_)
+        : _d{d_}, A{A_}, b{b_}, V{V_}, x0{x0_}
     {
     }
-
 
     // Return dimension
     unsigned int dimension() const
@@ -95,25 +126,25 @@ public:
     }
 
     // Change matrix A
-    void set_mat(MT const& A2)
+    void set_mat(MT const &A2)
     {
         A = A2;
     }
 
     // Change vector b
-    void set_vec(VT const& b2)
+    void set_vec(VT const &b2)
     {
         b = b2;
     }
 
     // Change simplex vertices
-    void set_vertices(MT const& V2)
+    void set_vertices(MT const &V2)
     {
         V = V2;
     }
 
     // Change ball center
-    void set_center(VT const& x02)
+    void set_center(VT const &x02)
     {
         x0 = x02;
     }
@@ -121,21 +152,24 @@ public:
     // Check if Point p lies in the simplex-ball intersection:
     //     A p <= b
     //     ||p - x0|| <= 1
-    int is_in(Point const& p, NT tol = NT(0)) const
+    int is_in(Point const &p, NT tol = NT(0)) const
     {
         VT p_vec = p.getCoefficients();
 
         // Check ball condition
         VT diff = p_vec - x0;
         NT radius_tol = NT(1) + tol;
-        if (diff.squaredNorm() > radius_tol * radius_tol) return 0;
+        if (diff.squaredNorm() > radius_tol * radius_tol)
+            return 0;
 
         // Check simplex inequalities A p <= b
         VT temp = b - A * p_vec;
-        const NT* Ax_b_data = temp.data();
+        const NT *Ax_b_data = temp.data();
 
-        for (int i = 0; i < A.rows(); i++) {
-            if ((*Ax_b_data) < NT(-tol)) {
+        for (int i = 0; i < A.rows(); i++)
+        {
+            if ((*Ax_b_data) < NT(-tol))
+            {
                 return 0;
             }
             Ax_b_data++;
@@ -144,18 +178,19 @@ public:
         return -1;
     }
 
-    int is_in_optimized(Point const& p,
-                         VT& Ar,
-                         VT& Av,
-                         NT const& lambda_prev,
-                         NT tol = NT(0)) const
+    int is_in_optimized(Point const &p,
+                        VT &Ar,
+                        VT &Av,
+                        NT const &lambda_prev,
+                        NT tol = NT(0)) const
     {
         VT p_vec = p.getCoefficients();
 
         // Ball membership check.
         VT diff = p_vec - x0;
         NT radius_tol = NT(1) + tol;
-        if (diff.squaredNorm() > radius_tol * radius_tol) return 0;
+        if (diff.squaredNorm() > radius_tol * radius_tol)
+            return 0;
 
         // Update cached A*x along the great-circle rotation:
         // x(lambda) = cos(lambda) * r + sin(lambda) * v.
@@ -164,16 +199,17 @@ public:
         Ar.noalias() = std::cos(lambda_prev) * Ar + std::sin(lambda_prev) * Av;
 
         VT temp = b - Ar;
-        const NT* Ax_b_data = temp.data();
+        const NT *Ax_b_data = temp.data();
 
-        for (int i = 0; i < A.rows(); i++) {
-            if ((*Ax_b_data) < NT(-tol)) return 0;
+        for (int i = 0; i < A.rows(); i++)
+        {
+            if ((*Ax_b_data) < NT(-tol))
+                return 0;
             Ax_b_data++;
         }
 
         return -1;
     }
-
 
     // Compute intersection parameters of the line r + lambda * v
     // with the simplex A x <= b.
@@ -181,10 +217,10 @@ public:
     // Returns:
     //   first  = smallest positive lambda
     //   second = largest negative lambda
-    std::pair<NT, NT> line_intersect(Point const& r, Point const& v) const
+    std::pair<NT, NT> line_intersect(Point const &r, Point const &v) const
     {
         NT lambda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         VT sum_nom;
@@ -195,18 +231,22 @@ public:
         sum_nom.noalias() = b - A * r.getCoefficients();
         sum_denom.noalias() = A * v.getCoefficients();
 
-        NT* sum_nom_data = sum_nom.data();
-        NT* sum_denom_data = sum_denom.data();
+        NT *sum_nom_data = sum_nom.data();
+        NT *sum_denom_data = sum_denom.data();
 
-        for (int i = 0; i < m; i++) {
-            if (*sum_denom_data != NT(0)) {
+        for (int i = 0; i < m; i++)
+        {
+            if (*sum_denom_data != NT(0))
+            {
                 lambda = *sum_nom_data / *sum_denom_data;
 
-                if (lambda < min_plus && lambda > NT(0)) {
+                if (lambda < min_plus && lambda > NT(0))
+                {
                     min_plus = lambda;
                 }
 
-                if (lambda > max_minus && lambda < NT(0)) {
+                if (lambda > max_minus && lambda < NT(0))
+                {
                     max_minus = lambda;
                 }
             }
@@ -228,14 +268,14 @@ public:
     //
     // If pos = true:
     //   returns (min positive lambda, facet index)
-    std::pair<NT, NT> line_intersect(Point const& r,
-                                     Point const& v,
-                                     VT& Ar,
-                                     VT& Av,
+    std::pair<NT, NT> line_intersect(Point const &r,
+                                     Point const &v,
+                                     VT &Ar,
+                                     VT &Av,
                                      bool pos = false) const
     {
         NT lambda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         VT sum_nom;
@@ -246,19 +286,25 @@ public:
         sum_nom.noalias() = b - Ar;
         Av.noalias() = A * v.getCoefficients();
 
-        NT* Av_data = Av.data();
-        NT* sum_nom_data = sum_nom.data();
+        NT *Av_data = Av.data();
+        NT *sum_nom_data = sum_nom.data();
 
-        for (int i = 0; i < m; i++) {
-            if (*Av_data != NT(0)) {
+        for (int i = 0; i < m; i++)
+        {
+            if (*Av_data != NT(0))
+            {
                 lambda = *sum_nom_data / *Av_data;
 
-                if (lambda < min_plus && lambda > NT(0)) {
+                if (lambda < min_plus && lambda > NT(0))
+                {
                     min_plus = lambda;
-                    if (pos) {
+                    if (pos)
+                    {
                         facet = i;
                     }
-                } else if (lambda > max_minus && lambda < NT(0)) {
+                }
+                else if (lambda > max_minus && lambda < NT(0))
+                {
                     max_minus = lambda;
                 }
             }
@@ -267,7 +313,8 @@ public:
             sum_nom_data++;
         }
 
-        if (pos) {
+        if (pos)
+        {
             return std::make_pair(min_plus, facet);
         }
 
@@ -280,16 +327,16 @@ public:
     //
     // Then Av is recomputed as:
     //     Av <- A * v
-    std::pair<NT, NT> line_intersect(Point const& r,
-                                     Point const& v,
-                                     VT& Ar,
-                                     VT& Av,
-                                     NT const& lambda_prev,
+    std::pair<NT, NT> line_intersect(Point const &r,
+                                     Point const &v,
+                                     VT &Ar,
+                                     VT &Av,
+                                     NT const &lambda_prev,
                                      bool pos = false) const
-    {   
-        (void)r;  
+    {
+        (void)r;
         NT lambda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         VT sum_nom;
@@ -300,19 +347,25 @@ public:
         sum_nom.noalias() = b - Ar;
         Av.noalias() = A * v.getCoefficients();
 
-        NT* sum_nom_data = sum_nom.data();
-        NT* Av_data = Av.data();
+        NT *sum_nom_data = sum_nom.data();
+        NT *Av_data = Av.data();
 
-        for (int i = 0; i < m; i++) {
-            if (*Av_data != NT(0)) {
+        for (int i = 0; i < m; i++)
+        {
+            if (*Av_data != NT(0))
+            {
                 lambda = *sum_nom_data / *Av_data;
 
-                if (lambda < min_plus && lambda > NT(0)) {
+                if (lambda < min_plus && lambda > NT(0))
+                {
                     min_plus = lambda;
-                    if (pos) {
+                    if (pos)
+                    {
                         facet = i;
                     }
-                } else if (lambda > max_minus && lambda < NT(0)) {
+                }
+                else if (lambda > max_minus && lambda < NT(0))
+                {
                     max_minus = lambda;
                 }
             }
@@ -321,7 +374,8 @@ public:
             sum_nom_data++;
         }
 
-        if (pos) {
+        if (pos)
+        {
             return std::make_pair(min_plus, facet);
         }
 
@@ -339,17 +393,15 @@ public:
     // Returns:
     //   first  = smallest positive angle lambda
     //   second = largest negative angle lambda
-    std::pair<NT, NT> compute_intersections(VT& Ar, VT& Av) const
+    std::pair<NT, NT> compute_intersections(VT &Ar, VT &Av) const
     {
-        NT D;
         NT C1;
         NT C2;
-        NT eval;
 
         NT max_root = std::numeric_limits<NT>::lowest();
         NT min_root = std::numeric_limits<NT>::max();
 
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         int m = num_of_hyperplanes();
@@ -358,63 +410,55 @@ public:
         bool set_positive_root = false;
         bool pos_D = false;
 
-        NT* Av_data = Av.data();
-        NT* Ar_data = Ar.data();
-        const NT* b_data = b.data();
+        NT *Av_data = Av.data();
+        NT *Ar_data = Ar.data();
+        const NT *b_data = b.data();
 
-        for (int i = 0; i < m; i++) {
-            D = (*Ar_data) * (*Ar_data)
-              + (*Av_data) * (*Av_data)
-              - (*b_data) * (*b_data);
-
-            if (D > NT(0)) {
+        for (int i = 0; i < m; i++)
+        {
+            if (compute_facet_roots(*Ar_data, *Av_data, *b_data, C1, C2))
+            {
                 pos_D = true;
 
-                NT denom = (*Ar_data) * (*Ar_data)
-                         + (*Av_data) * (*Av_data);
-
-                C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * std::sqrt(D))) / denom);
-                C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * std::sqrt(D))) / denom);
-
-                eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = pi() - C1;
-                }
-
-                if (C1 < min_plus && C1 > NT(0)) {
+                if (C1 < min_plus && C1 > NT(0))
+                {
                     min_plus = C1;
                     set_positive_root = true;
-                } else if (C1 > max_minus && C1 < NT(0)) {
+                }
+                else if (C1 > max_minus && C1 < NT(0))
+                {
                     max_minus = C1;
                     set_negative_root = true;
                 }
 
-                if (C1 > max_root && C1 < NT(2) * pi()) {
+                if (C1 > max_root && C1 < NT(2) * pi())
+                {
                     max_root = C1;
                 }
 
-                if ((C1 < min_root) && (C1 > (-NT(2) * pi()))) {
+                if ((C1 < min_root) && (C1 > (-NT(2) * pi())))
+                {
                     min_root = C1;
                 }
 
-                eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = pi() - C2;
-                }
-
-                if (C2 < min_plus && C2 > NT(0)) {
+                if (C2 < min_plus && C2 > NT(0))
+                {
                     min_plus = C2;
                     set_positive_root = true;
-                } else if (C2 > max_minus && C2 < NT(0)) {
+                }
+                else if (C2 > max_minus && C2 < NT(0))
+                {
                     max_minus = C2;
                     set_negative_root = true;
                 }
 
-                if (C2 > max_root && C2 < NT(2) * pi()) {
+                if (C2 > max_root && C2 < NT(2) * pi())
+                {
                     max_root = C2;
                 }
 
-                if (C2 < min_root && C2 > (-NT(2) * pi())) {
+                if (C2 < min_root && C2 > (-NT(2) * pi()))
+                {
                     min_root = C2;
                 }
             }
@@ -424,18 +468,26 @@ public:
             b_data++;
         }
 
-        if (!set_negative_root) {
-            if (pos_D) {
+        if (!set_negative_root)
+        {
+            if (pos_D)
+            {
                 max_minus = max_root - NT(2) * pi();
-            } else {
+            }
+            else
+            {
                 max_minus = NT(0);
             }
         }
 
-        if (!set_positive_root) {
-            if (pos_D) {
+        if (!set_positive_root)
+        {
+            if (pos_D)
+            {
                 min_plus = min_root + NT(2) * pi();
-            } else {
+            }
+            else
+            {
                 min_plus = NT(2) * pi();
             }
         }
@@ -445,10 +497,10 @@ public:
 
     // Great-circle intersection.
     // Computes Ar = A*r and Av = A*v, then calls compute_intersections.
-    std::pair<NT, NT> gc_intersect(Point const& r,
-                                   Point const& v,
-                                   VT& Ar,
-                                   VT& Av) const
+    std::pair<NT, NT> gc_intersect(Point const &r,
+                                   Point const &v,
+                                   VT &Ar,
+                                   VT &Av) const
     {
         Ar.noalias() = A * r.getCoefficients();
         Av.noalias() = A * v.getCoefficients();
@@ -457,11 +509,11 @@ public:
     }
 
     // Optimized great-circle intersection using previous lambda.
-    std::pair<NT, NT> gc_intersect(Point const& r,
-                                   Point const& v,
-                                   VT& Ar,
-                                   VT& Av,
-                                   NT const& lambda_prev) const
+    std::pair<NT, NT> gc_intersect(Point const &r,
+                                   Point const &v,
+                                   VT &Ar,
+                                   VT &Av,
+                                   NT const &lambda_prev) const
     {
         (void)r;
 
@@ -472,11 +524,11 @@ public:
     }
 
     // Great-circle intersection assuming Ar is already up to date.
-    std::pair<NT, NT> gc_intersect_optimized(Point const& r,
-                                             Point const& v,
-                                             VT& Ar,
-                                             VT& Av,
-                                             NT const& lambda_prev) const
+    std::pair<NT, NT> gc_intersect_optimized(Point const &r,
+                                             Point const &v,
+                                             VT &Ar,
+                                             VT &Av,
+                                             NT const &lambda_prev) const
     {
         (void)r;
         (void)lambda_prev;
@@ -497,12 +549,10 @@ public:
     // Returns:
     //   first  = smallest positive angle lambda
     //   second = index of the facet hit
-    std::pair<NT, int> compute_intersections_positive(VT const& Ar, VT const& Av) const
+    std::pair<NT, int> compute_intersections_positive(VT const &Ar, VT const &Av) const
     {
-        NT D;
         NT C1;
         NT C2;
-        NT eval;
         NT min_root = std::numeric_limits<NT>::max();
         NT min_plus = std::numeric_limits<NT>::max();
 
@@ -513,52 +563,38 @@ public:
         bool set_positive_root = false;
         bool pos_D = false;
 
-        const NT* Av_data = Av.data();
-        const NT* Ar_data = Ar.data();
-        const NT* b_data = b.data();
+        const NT *Av_data = Av.data();
+        const NT *Ar_data = Ar.data();
+        const NT *b_data = b.data();
 
-        for (int i = 0; i < m; i++) {
-            D = (*Ar_data) * (*Ar_data)
-              + (*Av_data) * (*Av_data)
-              - (*b_data) * (*b_data);
-
-            if (D > NT(0)) {
+        for (int i = 0; i < m; i++)
+        {
+            if (compute_facet_roots(*Ar_data, *Av_data, *b_data, C1, C2))
+            {
                 pos_D = true;
 
-                NT denom = (*Ar_data) * (*Ar_data)
-                         + (*Av_data) * (*Av_data);
-
-                C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * std::sqrt(D))) / denom);
-                C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * std::sqrt(D))) / denom);
-
-                eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = pi() - C1;
-                }
-
-                if (C1 < min_plus && C1 > NT(0)) {
+                if (C1 < min_plus && C1 > NT(0))
+                {
                     min_plus = C1;
                     set_positive_root = true;
                     facet = i;
                 }
 
-                if ((C1 < min_root) && (C1 > (-NT(2) * pi()))) {
+                if ((C1 < min_root) && (C1 > (-NT(2) * pi())))
+                {
                     min_root = C1;
                     facet_min = i;
                 }
 
-                eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = pi() - C2;
-                }
-
-                if (C2 < min_plus && C2 > NT(0)) {
+                if (C2 < min_plus && C2 > NT(0))
+                {
                     min_plus = C2;
                     set_positive_root = true;
                     facet = i;
                 }
 
-                if (C2 < min_root && C2 > (-NT(2) * pi())) {
+                if (C2 < min_root && C2 > (-NT(2) * pi()))
+                {
                     min_root = C2;
                     facet_min = i;
                 }
@@ -569,11 +605,15 @@ public:
             b_data++;
         }
 
-        if (!set_positive_root) {
-            if (pos_D) {
+        if (!set_positive_root)
+        {
+            if (pos_D)
+            {
                 min_plus = min_root + NT(2) * pi();
                 facet = facet_min;
-            } else {
+            }
+            else
+            {
                 min_plus = NT(2) * pi();
             }
         }
@@ -583,10 +623,10 @@ public:
 
     // Great-circle first positive intersection.
     // Computes Ar = A*r and Av = A*v, then calls compute_intersections_positive.
-    std::pair<NT, int> gc_intersect_positive(Point const& r,
-                                             Point const& v,
-                                             VT& Ar,
-                                             VT& Av) const
+    std::pair<NT, int> gc_intersect_positive(Point const &r,
+                                             Point const &v,
+                                             VT &Ar,
+                                             VT &Av) const
     {
         Ar.noalias() = A * r.getCoefficients();
         Av.noalias() = A * v.getCoefficients();
@@ -595,11 +635,11 @@ public:
     }
 
     // Optimized great-circle first positive intersection using previous lambda.
-    std::pair<NT, int> gc_intersect_positive(Point const& r,
-                                             Point const& v,
-                                             VT& Ar,
-                                             VT& Av,
-                                             NT const& lambda_prev) const
+    std::pair<NT, int> gc_intersect_positive(Point const &r,
+                                             Point const &v,
+                                             VT &Ar,
+                                             VT &Av,
+                                             NT const &lambda_prev) const
     {
         (void)r;
 
@@ -609,7 +649,6 @@ public:
         return compute_intersections_positive(Ar, Av);
     }
 
-
     // Compute all intersection roots of the great circle
     // x(lambda) = cos(lambda) * r + sin(lambda) * v
     // with the simplex boundary A x <= b.
@@ -617,68 +656,60 @@ public:
     // Returns:
     //   first  = negative roots in (-pi, 0)
     //   second = positive roots in (0, pi)
-    std::pair<VT, VT> compute_intersections_all_roots(VT& Ar, VT& Av) const
+    std::pair<VT, VT> compute_intersections_all_roots(VT &Ar, VT &Av) const
     {
         std::vector<NT> neg_roots;
         std::vector<NT> pos_roots;
 
         int m = num_of_hyperplanes();
 
-        NT* Av_data = Av.data();
-        NT* Ar_data = Ar.data();
-        const NT* b_data = b.data();
+        NT *Av_data = Av.data();
+        NT *Ar_data = Ar.data();
+        const NT *b_data = b.data();
 
-        for (int i = 0; i < m; i++) {
-            NT denom = (*Ar_data) * (*Ar_data) + (*Av_data) * (*Av_data);
-            NT D = denom - (*b_data) * (*b_data);
+        for (int i = 0; i < m; i++)
+        {
+            NT C1;
+            NT C2;
 
-            if (D > NT(0)) {
-                NT sqrtD = std::sqrt(D);
-
-                NT C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * sqrtD)) / denom);
-                NT C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * sqrtD)) / denom);
-
-                NT eval = (*Ar_data) * std::cos(C1)
-                        + (*Av_data) * std::sin(C1)
-                        - (*b_data);
-
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = pi() - C1;
-                }
-
-                if (C1 > pi()) {
+            if (compute_facet_roots(*Ar_data, *Av_data, *b_data, C1, C2))
+            {
+                if (C1 > pi())
+                {
                     C1 -= NT(2) * pi();
-                } else if (C1 < -pi()) {
+                }
+                else if (C1 < -pi())
+                {
                     C1 += NT(2) * pi();
                 }
 
-                if ((C1 > -pi()) && (C1 < NT(0))) {
+                if ((C1 > -pi()) && (C1 < NT(0)))
+                {
                     neg_roots.push_back(C1);
-                } else if ((C1 < pi()) && (C1 > NT(0))) {
+                }
+                else if ((C1 < pi()) && (C1 > NT(0)))
+                {
                     pos_roots.push_back(C1);
                 }
 
-                eval = (*Ar_data) * std::cos(C2)
-                     + (*Av_data) * std::sin(C2)
-                     - (*b_data);
-
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = pi() - C2;
-                }
-
-                if (C2 > pi()) {
+                if (C2 > pi())
+                {
                     C2 -= NT(2) * pi();
-                } else if (C2 < -pi()) {
+                }
+                else if (C2 < -pi())
+                {
                     C2 += NT(2) * pi();
                 }
 
-                if ((C2 > -pi()) && (C2 < NT(0))) {
+                if ((C2 > -pi()) && (C2 < NT(0)))
+                {
                     neg_roots.push_back(C2);
-                } else if ((C2 < pi()) && (C2 > NT(0))) {
+                }
+                else if ((C2 < pi()) && (C2 > NT(0)))
+                {
                     pos_roots.push_back(C2);
                 }
             }
-
             Av_data++;
             Ar_data++;
             b_data++;
@@ -688,12 +719,14 @@ public:
         std::sort(pos_roots.begin(), pos_roots.end());
 
         VT neg_roots_vec(neg_roots.size());
-        for (unsigned int i = 0; i < neg_roots.size(); i++) {
+        for (unsigned int i = 0; i < neg_roots.size(); i++)
+        {
             neg_roots_vec(i) = neg_roots[i];
         }
 
         VT pos_roots_vec(pos_roots.size());
-        for (unsigned int i = 0; i < pos_roots.size(); i++) {
+        for (unsigned int i = 0; i < pos_roots.size(); i++)
+        {
             pos_roots_vec(i) = pos_roots[i];
         }
 
@@ -701,10 +734,10 @@ public:
     }
 
     // Great-circle all-roots intersection.
-    std::pair<VT, VT> gc_intersect_all_roots(Point const& r,
-                                             Point const& v,
-                                             VT& Ar,
-                                             VT& Av) const
+    std::pair<VT, VT> gc_intersect_all_roots(Point const &r,
+                                             Point const &v,
+                                             VT &Ar,
+                                             VT &Av) const
     {
         Ar.noalias() = A * r.getCoefficients();
         Av.noalias() = A * v.getCoefficients();
@@ -713,11 +746,11 @@ public:
     }
 
     // Optimized great-circle all-roots intersection using previous lambda.
-    std::pair<VT, VT> gc_intersect_all_roots(Point const& r,
-                                             Point const& v,
-                                             VT& Ar,
-                                             VT& Av,
-                                             NT const& lambda_prev) const
+    std::pair<VT, VT> gc_intersect_all_roots(Point const &r,
+                                             Point const &v,
+                                             VT &Ar,
+                                             VT &Av,
+                                             NT const &lambda_prev) const
     {
         (void)r;
 
@@ -730,7 +763,7 @@ public:
     // Apply linear transformation T to the simplex inequalities.
     // If the point transformation is x <- T^{-1} x,
     // then the H-representation matrix changes as A <- A * T.
-    void linear_transformIt(MT const& T)
+    void linear_transformIt(MT const &T)
     {
         A = A * T;
     }
@@ -738,7 +771,7 @@ public:
     // Shift the simplex by a vector c.
     // For A x <= b, after shifting x <- x + c,
     // the right-hand side changes as b <- b - A*c.
-    void shift(VT const& c)
+    void shift(VT const &c)
     {
         b -= A * c;
     }
@@ -748,10 +781,10 @@ public:
     //
     // p_p is the tangent-space projector:
     //     p_p = I - p p^T
-    void compute_reflection(VT& v,
-                            VT const& p,
-                            MT const& p_p,
-                            int const& facet) const
+    void compute_reflection(VT &v,
+                            VT const &p,
+                            MT const &p_p,
+                            int const &facet) const
     {
         (void)p;
 
@@ -760,6 +793,5 @@ public:
 
         v += -NT(2) * v.dot(u) * u;
     }
-
 };
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -419,6 +419,8 @@ add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection)
 add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection_positive
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection_positive)
+add_test(NAME simplexintersectball_incremental_rotation_matches_fresh
+          COMMAND simplexintersectball_test -tc=simplexintersectball_incremental_rotation_matches_fresh)
 add_test(NAME simplexintersectball_3d_tetrahedron_gc_all_roots
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_all_roots)
 add_test(NAME simplexintersectball_3d_tetrahedron_reflection

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -419,6 +419,8 @@ add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection)
 add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection_positive
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection_positive)
+add_test(NAME simplexintersectball_3d_tetrahedron_gc_all_roots
+          COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_all_roots)
 add_test(NAME simplexintersectball_3d_tetrahedron_reflection
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_reflection)
 add_test(NAME full_dimensional_polytope_orthogonality

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -413,6 +413,12 @@ add_test(NAME simplexintersectball_basic_membership
           COMMAND simplexintersectball_test -tc=simplexintersectball_basic_membership)
 add_test(NAME simplexintersectball_line_intersection
           COMMAND simplexintersectball_test -tc=simplexintersectball_line_intersection)
+add_test(NAME simplexintersectball_3d_tetrahedron_membership
+          COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_membership)
+add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection
+          COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection)
+add_test(NAME simplexintersectball_3d_tetrahedron_reflection
+          COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_reflection)
 add_test(NAME full_dimensional_polytope_orthogonality
           COMMAND full_dimensional_polytope_test -tc=full_dimensional_polytope_orthogonality)
 add_test(NAME full_dimensional_polytope_infeasible

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -417,6 +417,8 @@ add_test(NAME simplexintersectball_3d_tetrahedron_membership
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_membership)
 add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection)
+add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection_positive
+          COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection_positive)
 add_test(NAME simplexintersectball_3d_tetrahedron_reflection
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_reflection)
 add_test(NAME full_dimensional_polytope_orthogonality

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -408,6 +408,11 @@ add_test(NAME full_dimensional_polytope_hypercube_intersection
           COMMAND full_dimensional_polytope_test -tc=full_dimensional_polytope_hypercube_intersection)
 add_test(NAME full_dimensional_polytope_sparse_constraint
           COMMAND full_dimensional_polytope_test -tc=full_dimensional_polytope_sparse_constraint)
+add_executable (simplexintersectball_test simplexintersectball_test.cpp $<TARGET_OBJECTS:test_main>)
+add_test(NAME simplexintersectball_basic_membership
+          COMMAND simplexintersectball_test -tc=simplexintersectball_basic_membership)
+add_test(NAME simplexintersectball_line_intersection
+          COMMAND simplexintersectball_test -tc=simplexintersectball_line_intersection)
 add_test(NAME full_dimensional_polytope_orthogonality
           COMMAND full_dimensional_polytope_test -tc=full_dimensional_polytope_orthogonality)
 add_test(NAME full_dimensional_polytope_infeasible

--- a/test/simplexintersectball_test.cpp
+++ b/test/simplexintersectball_test.cpp
@@ -19,10 +19,10 @@ SimplexBall make_3d_tetrahedron_unit_ball()
     // Tetrahedron in R^3:
     // x >= 0, y >= 0, z >= 0, x + y + z <= 2
     MT A(4, 3);
-    A << -1,  0,  0,
-          0, -1,  0,
-          0,  0, -1,
-          1,  1,  1;
+    A << -1, 0, 0,
+        0, -1, 0,
+        0, 0, -1,
+        1, 1, 1;
 
     VT b(4);
     b << 0, 0, 0, 2;
@@ -31,8 +31,8 @@ SimplexBall make_3d_tetrahedron_unit_ball()
     // (0,0,0), (2,0,0), (0,2,0), (0,0,2)
     MT V(3, 4);
     V << 0, 2, 0, 0,
-         0, 0, 2, 0,
-         0, 0, 0, 2;
+        0, 0, 2, 0,
+        0, 0, 0, 2;
 
     VT x0(3);
     x0 << 0, 0, 0;
@@ -47,9 +47,9 @@ TEST_CASE("simplexintersectball_basic_membership")
     // Simplex in R^2:
     // x >= 0, y >= 0, x + y <= 1
     MT A(3, 2);
-    A << -1,  0,
-          0, -1,
-          1,  1;
+    A << -1, 0,
+        0, -1,
+        1, 1;
 
     VT b(3);
     b << 0, 0, 1;
@@ -57,7 +57,7 @@ TEST_CASE("simplexintersectball_basic_membership")
     // Vertices stored column-wise: (0,0), (1,0), (0,1)
     MT V(2, 3);
     V << 0, 1, 0,
-         0, 0, 1;
+        0, 0, 1;
 
     VT x0(2);
     x0 << 0, 0;
@@ -89,16 +89,16 @@ TEST_CASE("simplexintersectball_line_intersection")
     unsigned int d = 2;
 
     MT A(3, 2);
-    A << -1,  0,
-          0, -1,
-          1,  1;
+    A << -1, 0,
+        0, -1,
+        1, 1;
 
     VT b(3);
     b << 0, 0, 1;
 
     MT V(2, 3);
     V << 0, 1, 0,
-         0, 0, 1;
+        0, 0, 1;
 
     VT x0(2);
     x0 << 0, 0;
@@ -195,12 +195,39 @@ TEST_CASE("simplexintersectball_3d_tetrahedron_gc_intersection_positive")
     CHECK(hit.second == 1);
 }
 
+TEST_CASE("simplexintersectball_incremental_rotation_matches_fresh")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    NT inv_sqrt3 = NT(1) / std::sqrt(NT(3));
+    NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
+
+    VT r0(3);
+    r0 << inv_sqrt3, inv_sqrt3, inv_sqrt3;
+    VT v0(3);
+    v0 << inv_sqrt2, -inv_sqrt2, 0;
+    Point pr0(r0), pv0(v0);
+
+    VT Ar, Av;
+    K.gc_intersect(pr0, pv0, Ar, Av);
+
+    NT lambda = 0.3;
+    std::pair<NT, NT> inc = K.gc_intersect(pr0, pv0, Ar, Av, lambda);
+
+    VT r1 = std::cos(lambda) * r0 + std::sin(lambda) * v0;
+    Point pr1(r1);
+    VT Ar2, Av2;
+    std::pair<NT, NT> fresh = K.gc_intersect(pr1, pv0, Ar2, Av2);
+
+    CHECK(inc.first == doctest::Approx(fresh.first));
+    CHECK(inc.second == doctest::Approx(fresh.second));
+}
+
 TEST_CASE("simplexintersectball_3d_tetrahedron_reflection")
 {
     SimplexBall K = make_3d_tetrahedron_unit_ball();
 
     NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
-
     // Point on the unit sphere and on the facet y = 0
     VT p(3);
     p << inv_sqrt2, 0, inv_sqrt2;

--- a/test/simplexintersectball_test.cpp
+++ b/test/simplexintersectball_test.cpp
@@ -219,3 +219,50 @@ TEST_CASE("simplexintersectball_3d_tetrahedron_reflection")
     CHECK(v(1) == doctest::Approx(1.0));
     CHECK(v(2) == doctest::Approx(0.0));
 }
+
+TEST_CASE("simplexintersectball_3d_tetrahedron_gc_all_roots")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    NT inv_sqrt3 = NT(1) / std::sqrt(NT(3));
+    NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
+
+    VT r_vec(3);
+    r_vec << inv_sqrt3, inv_sqrt3, inv_sqrt3;
+    Point r(r_vec);
+
+    VT v_vec(3);
+    v_vec << inv_sqrt2, -inv_sqrt2, 0;
+    Point v(v_vec);
+
+    VT Ar;
+    VT Av;
+
+    std::pair<VT, VT> roots = K.gc_intersect_all_roots(r, v, Ar, Av);
+
+    NT alpha = std::atan(std::sqrt(NT(2) / NT(3)));
+
+    CHECK(roots.first.rows() >= 1);
+    CHECK(roots.second.rows() >= 1);
+
+    bool found_negative_alpha = false;
+    for (int i = 0; i < roots.first.rows(); ++i)
+    {
+        if (std::abs(roots.first(i) + alpha) < NT(1e-08))
+        {
+            found_negative_alpha = true;
+        }
+    }
+
+    bool found_positive_alpha = false;
+    for (int i = 0; i < roots.second.rows(); ++i)
+    {
+        if (std::abs(roots.second(i) - alpha) < NT(1e-08))
+        {
+            found_positive_alpha = true;
+        }
+    }
+
+    CHECK(found_negative_alpha);
+    CHECK(found_positive_alpha);
+}

--- a/test/simplexintersectball_test.cpp
+++ b/test/simplexintersectball_test.cpp
@@ -169,6 +169,32 @@ TEST_CASE("simplexintersectball_3d_tetrahedron_gc_intersection")
     CHECK(interval.second == doctest::Approx(-alpha));
 }
 
+TEST_CASE("simplexintersectball_3d_tetrahedron_gc_intersection_positive")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    NT inv_sqrt3 = NT(1) / std::sqrt(NT(3));
+    NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
+
+    VT r_vec(3);
+    r_vec << inv_sqrt3, inv_sqrt3, inv_sqrt3;
+    Point r(r_vec);
+
+    VT v_vec(3);
+    v_vec << inv_sqrt2, -inv_sqrt2, 0;
+    Point v(v_vec);
+
+    VT Ar;
+    VT Av;
+
+    std::pair<NT, int> hit = K.gc_intersect_positive(r, v, Ar, Av);
+
+    NT alpha = std::atan(std::sqrt(NT(2) / NT(3)));
+
+    CHECK(hit.first == doctest::Approx(alpha));
+    CHECK(hit.second == 1);
+}
+
 TEST_CASE("simplexintersectball_3d_tetrahedron_reflection")
 {
     SimplexBall K = make_3d_tetrahedron_unit_ball();

--- a/test/simplexintersectball_test.cpp
+++ b/test/simplexintersectball_test.cpp
@@ -1,0 +1,92 @@
+#include "doctest.h"
+
+#include <Eigen/Eigen>
+
+#include "convex_bodies/simplexintersectball.h"
+#include "cartesian_geom/cartesian_kernel.h"
+
+typedef double NT;
+typedef Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> MT;
+typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+typedef Cartesian<NT> Kernel;
+typedef typename Kernel::Point Point;
+typedef SimplexIntersectBall<Point> SimplexBall;
+
+TEST_CASE("simplexintersectball_basic_membership")
+{
+    unsigned int d = 2;
+
+    // Simplex in R^2:
+    // x >= 0, y >= 0, x + y <= 1
+    MT A(3, 2);
+    A << -1,  0,
+          0, -1,
+          1,  1;
+
+    VT b(3);
+    b << 0, 0, 1;
+
+    // Vertices stored column-wise: (0,0), (1,0), (0,1)
+    MT V(2, 3);
+    V << 0, 1, 0,
+         0, 0, 1;
+
+    VT x0(2);
+    x0 << 0, 0;
+
+    SimplexBall K(d, A, b, V, x0);
+
+    CHECK(K.dimension() == 2);
+    CHECK(K.num_of_hyperplanes() == 3);
+
+    VT inside_vec(2);
+    inside_vec << 0.2, 0.2;
+    Point inside(inside_vec);
+
+    VT outside_simplex_vec(2);
+    outside_simplex_vec << 0.8, 0.8;
+    Point outside_simplex(outside_simplex_vec);
+
+    VT outside_ball_vec(2);
+    outside_ball_vec << 1.2, 0.0;
+    Point outside_ball(outside_ball_vec);
+
+    CHECK(K.is_in(inside) == -1);
+    CHECK(K.is_in(outside_simplex) == 0);
+    CHECK(K.is_in(outside_ball) == 0);
+}
+
+TEST_CASE("simplexintersectball_line_intersection")
+{
+    unsigned int d = 2;
+
+    MT A(3, 2);
+    A << -1,  0,
+          0, -1,
+          1,  1;
+
+    VT b(3);
+    b << 0, 0, 1;
+
+    MT V(2, 3);
+    V << 0, 1, 0,
+         0, 0, 1;
+
+    VT x0(2);
+    x0 << 0, 0;
+
+    SimplexBall K(d, A, b, V, x0);
+
+    VT r_vec(2);
+    r_vec << 0.2, 0.2;
+    Point r(r_vec);
+
+    VT v_vec(2);
+    v_vec << 1.0, 0.0;
+    Point v(v_vec);
+
+    std::pair<NT, NT> interval = K.line_intersect(r, v);
+
+    CHECK(interval.first == doctest::Approx(0.6));
+    CHECK(interval.second == doctest::Approx(-0.2));
+}

--- a/test/simplexintersectball_test.cpp
+++ b/test/simplexintersectball_test.cpp
@@ -12,6 +12,34 @@ typedef Cartesian<NT> Kernel;
 typedef typename Kernel::Point Point;
 typedef SimplexIntersectBall<Point> SimplexBall;
 
+SimplexBall make_3d_tetrahedron_unit_ball()
+{
+    unsigned int d = 3;
+
+    // Tetrahedron in R^3:
+    // x >= 0, y >= 0, z >= 0, x + y + z <= 2
+    MT A(4, 3);
+    A << -1,  0,  0,
+          0, -1,  0,
+          0,  0, -1,
+          1,  1,  1;
+
+    VT b(4);
+    b << 0, 0, 0, 2;
+
+    // Vertices stored column-wise:
+    // (0,0,0), (2,0,0), (0,2,0), (0,0,2)
+    MT V(3, 4);
+    V << 0, 2, 0, 0,
+         0, 0, 2, 0,
+         0, 0, 0, 2;
+
+    VT x0(3);
+    x0 << 0, 0, 0;
+
+    return SimplexBall(d, A, b, V, x0);
+}
+
 TEST_CASE("simplexintersectball_basic_membership")
 {
     unsigned int d = 2;
@@ -89,4 +117,79 @@ TEST_CASE("simplexintersectball_line_intersection")
 
     CHECK(interval.first == doctest::Approx(0.6));
     CHECK(interval.second == doctest::Approx(-0.2));
+}
+
+TEST_CASE("simplexintersectball_3d_tetrahedron_membership")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    CHECK(K.dimension() == 3);
+    CHECK(K.num_of_hyperplanes() == 4);
+
+    VT inside_vec(3);
+    inside_vec << 0.3, 0.3, 0.3;
+    Point inside(inside_vec);
+
+    VT outside_simplex_vec(3);
+    outside_simplex_vec << -0.1, 0.2, 0.2;
+    Point outside_simplex(outside_simplex_vec);
+
+    VT outside_ball_vec(3);
+    outside_ball_vec << 1.2, 0.0, 0.0;
+    Point outside_ball(outside_ball_vec);
+
+    CHECK(K.is_in(inside) == -1);
+    CHECK(K.is_in(outside_simplex) == 0);
+    CHECK(K.is_in(outside_ball) == 0);
+}
+
+TEST_CASE("simplexintersectball_3d_tetrahedron_gc_intersection")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    NT inv_sqrt3 = NT(1) / std::sqrt(NT(3));
+    NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
+
+    VT r_vec(3);
+    r_vec << inv_sqrt3, inv_sqrt3, inv_sqrt3;
+    Point r(r_vec);
+
+    VT v_vec(3);
+    v_vec << inv_sqrt2, -inv_sqrt2, 0;
+    Point v(v_vec);
+
+    VT Ar;
+    VT Av;
+
+    std::pair<NT, NT> interval = K.gc_intersect(r, v, Ar, Av);
+
+    NT alpha = std::atan(std::sqrt(NT(2) / NT(3)));
+
+    CHECK(interval.first == doctest::Approx(alpha));
+    CHECK(interval.second == doctest::Approx(-alpha));
+}
+
+TEST_CASE("simplexintersectball_3d_tetrahedron_reflection")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
+
+    // Point on the unit sphere and on the facet y = 0
+    VT p(3);
+    p << inv_sqrt2, 0, inv_sqrt2;
+
+    // Tangent direction pointing outside through y < 0
+    VT v(3);
+    v << 0, -1, 0;
+
+    MT projector = MT::Identity(3, 3) - p * p.transpose();
+
+    int facet = 1; // y = 0 facet, represented by -y <= 0
+
+    K.compute_reflection(v, p, projector, facet);
+
+    CHECK(v(0) == doctest::Approx(0.0));
+    CHECK(v(1) == doctest::Approx(1.0));
+    CHECK(v(2) == doctest::Approx(0.0));
 }


### PR DESCRIPTION
## Summary

This PR adds `SimplexIntersectBall`, a convex body representing the intersection of a simplex in H-representation with a unit ball.

The body models:

\[
K = \{x \in \mathbb{R}^d : Ax \le b,\ \|x - x_0\| \le 1\}.
\]

## Implemented functionality

- `dimension()`
- `num_of_hyperplanes()`
- `is_in(...)`
- `is_in_optimized(...)`
- `line_intersect(...)`
- `gc_intersect(...)`
- `gc_intersect_positive(...)`
- `gc_intersect_all_roots(...)`
- `compute_reflection(...)`
- `linear_transformIt(...)`
- `shift(...)`

## Tests added

Adds unit tests for:

- 2D simplex membership
- line intersection
- 3D tetrahedron membership
- great-circle interval computation
- positive great-circle intersection
- all great-circle roots
- incremental great-circle update against fresh recomputation
- reflection on a tetrahedron facet

## Validation

Tested locally with:

```bash
cmake --build build --target simplexintersectball_test
cd build
ctest -R simplexintersectball --output-on-failure