### PR TITLE
Add simplex-ball connected components and starting points

### DIFF
--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -2,7 +2,6 @@
 #define SIMPLEXINTERSECTBALL_H
 
 #include <limits>
-#include <iostream>
 #include <cmath>
 #include <utility>
 #include <vector>
@@ -31,8 +30,7 @@ public:
     typedef Point                                             PointType;
     typedef typename Point::FT                                NT;
     typedef MT_type                                           MT;
-    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT;
-    typedef Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> DenseMT;
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT; 
 
         static NT pi()
     {
@@ -45,27 +43,20 @@ private:
     VT           b;   // vector b, such that A x <= b
     MT           V;   // simplex vertices, stored column-wise
     VT           x0;  // center of the unit ball
-    VT           Vnorms;
+
 
 public:
     SimplexIntersectBall() {}
 
     SimplexIntersectBall(unsigned int d_,
-                         MT const& A_,
-                         VT const& b_,
-                         MT const& V_,
-                         VT const& x0_)
-        : _d{d_}, A{A_}, b{b_}, V{V_}, x0{x0_}
+                     MT const& A_,
+                     VT const& b_,
+                     MT const& V_,
+                     VT const& x0_)
+    : _d{d_}, A{A_}, b{b_}, V{V_}, x0{x0_}
     {
-        Vnorms = V.colwise().norm();
-        Vnorms = Vnorms.cwiseProduct(Vnorms);
     }
 
-    // Copy constructor
-    SimplexIntersectBall(SimplexIntersectBall<Point, MT_type> const& p)
-        : _d{p._d}, A{p.A}, b{p.b}, V{p.V}, x0{p.x0}, Vnorms{p.Vnorms}
-    {
-    }
 
     // Return dimension
     unsigned int dimension() const
@@ -119,8 +110,6 @@ public:
     void set_vertices(MT const& V2)
     {
         V = V2;
-        Vnorms = V.colwise().norm();
-        Vnorms = Vnorms.cwiseProduct(Vnorms);
     }
 
     // Change ball center
@@ -621,7 +610,7 @@ public:
     }
 
 
-        // Compute all intersection roots of the great circle
+    // Compute all intersection roots of the great circle
     // x(lambda) = cos(lambda) * r + sin(lambda) * v
     // with the simplex boundary A x <= b.
     //

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -1,0 +1,769 @@
+#ifndef SIMPLEXINTERSECTBALL_H
+#define SIMPLEXINTERSECTBALL_H
+
+#include <limits>
+#include <iostream>
+#include <cmath>
+#include <utility>
+#include <Eigen/Eigen>
+
+/// This class represents the intersection of a simplex with the unit ball.
+/// The simplex is given in H-representation:
+///     A x <= b
+/// and the ball is:
+///     ||x - x0|| <= 1
+///
+/// Return convention for is_in:
+///     -1 : inside
+///      0 : outside
+///
+/// \tparam Point Point type used by volesti
+/// \tparam MT_type Matrix type for A
+template
+<
+    typename Point,
+    typename MT_type = Eigen::Matrix<typename Point::FT, Eigen::Dynamic, Eigen::Dynamic>
+>
+class SimplexIntersectBall {
+public:
+    typedef Point                                             PointType;
+    typedef typename Point::FT                                NT;
+    typedef MT_type                                           MT;
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT;
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> DenseMT;
+
+private:
+    unsigned int _d;  // dimension
+    MT           A;   // matrix A
+    VT           b;   // vector b, such that A x <= b
+    MT           V;   // simplex vertices, stored column-wise
+    VT           x0;  // center of the unit ball
+    VT           Vnorms;
+
+public:
+    SimplexIntersectBall() {}
+
+    SimplexIntersectBall(unsigned int d_,
+                         MT const& A_,
+                         VT const& b_,
+                         MT const& V_,
+                         VT const& x0_)
+        : _d{d_}, A{A_}, b{b_}, V{V_}, x0{x0_}
+    {
+        Vnorms = V.colwise().norm();
+        Vnorms = Vnorms.cwiseProduct(Vnorms);
+    }
+
+    // Copy constructor
+    SimplexIntersectBall(SimplexIntersectBall<Point, MT_type> const& p)
+        : _d{p._d}, A{p.A}, b{p.b}, V{p.V}, x0{p.x0}, Vnorms{p.Vnorms}
+    {
+    }
+
+    // Return dimension
+    unsigned int dimension() const
+    {
+        return _d;
+    }
+
+    // Return number of facets / hyperplanes
+    int num_of_hyperplanes() const
+    {
+        return A.rows();
+    }
+
+    // Return matrix A
+    MT get_mat() const
+    {
+        return A;
+    }
+
+    // Return vector b
+    VT get_vec() const
+    {
+        return b;
+    }
+
+    // Return simplex vertices
+    MT get_vertices() const
+    {
+        return V;
+    }
+
+    // Return center of the unit ball
+    VT get_center() const
+    {
+        return x0;
+    }
+
+    // Change matrix A
+    void set_mat(MT const& A2)
+    {
+        A = A2;
+    }
+
+    // Change vector b
+    void set_vec(VT const& b2)
+    {
+        b = b2;
+    }
+
+    // Change simplex vertices
+    void set_vertices(MT const& V2)
+    {
+        V = V2;
+        Vnorms = V.colwise().norm();
+        Vnorms = Vnorms.cwiseProduct(Vnorms);
+    }
+
+    // Change ball center
+    void set_center(VT const& x02)
+    {
+        x0 = x02;
+    }
+
+    // Check if Point p lies in the simplex-ball intersection:
+    //     A p <= b
+    //     ||p - x0|| <= 1
+    int is_in(Point const& p, NT tol = NT(0)) const
+    {
+        VT p_vec = p.getCoefficients();
+
+        // Check ball condition
+        VT diff = p_vec - x0;
+        if (diff.squaredNorm() > NT(1) + tol) {
+            return 0;
+        }
+
+        // Check simplex inequalities A p <= b
+        VT temp = b - A * p_vec;
+        const NT* Ax_b_data = temp.data();
+
+        for (int i = 0; i < A.rows(); i++) {
+            if ((*Ax_b_data) < NT(-tol)) {
+                return 0;
+            }
+            Ax_b_data++;
+        }
+
+        return -1;
+    }
+
+    int is_in_optimized(Point const& p,
+                    VT& Ar,
+                    VT& Av,
+                    NT const& lambda_prev,
+                    NT tol = NT(0)) const
+    {
+        VT p_vec = p.getCoefficients();
+
+        // Ball membership check.
+        VT diff = p_vec - x0;
+        if (diff.squaredNorm() > NT(1) + tol) return 0;
+
+        // Update cached A*x along the great-circle rotation:
+        // x(lambda) = cos(lambda) * r + sin(lambda) * v.
+        //
+        // Here Ar stores A*r and Av stores A*v from the previous step.
+        Ar.noalias() = std::cos(lambda_prev) * Ar + std::sin(lambda_prev) * Av;
+
+        VT temp = b - Ar;
+        const NT* Ax_b_data = temp.data();
+
+        for (int i = 0; i < A.rows(); i++) {
+            if ((*Ax_b_data) < NT(-tol)) return 0;
+            Ax_b_data++;
+        }
+
+        return -1;
+    }
+
+
+    // Compute intersection parameters of the line r + lambda * v
+    // with the simplex A x <= b.
+    //
+    // Returns:
+    //   first  = smallest positive lambda
+    //   second = largest negative lambda
+    std::pair<NT, NT> line_intersect(Point const& r, Point const& v) const
+    {
+        NT lambda = 0;
+        NT min_plus  = std::numeric_limits<NT>::max();
+        NT max_minus = std::numeric_limits<NT>::lowest();
+
+        VT sum_nom;
+        VT sum_denom;
+
+        int m = num_of_hyperplanes();
+
+        sum_nom.noalias() = b - A * r.getCoefficients();
+        sum_denom.noalias() = A * v.getCoefficients();
+
+        NT* sum_nom_data = sum_nom.data();
+        NT* sum_denom_data = sum_denom.data();
+
+        for (int i = 0; i < m; i++) {
+            if (*sum_denom_data != NT(0)) {
+                lambda = *sum_nom_data / *sum_denom_data;
+
+                if (lambda < min_plus && lambda > NT(0)) {
+                    min_plus = lambda;
+                }
+
+                if (lambda > max_minus && lambda < NT(0)) {
+                    max_minus = lambda;
+                }
+            }
+
+            sum_nom_data++;
+            sum_denom_data++;
+        }
+
+        return std::make_pair(min_plus, max_minus);
+    }
+
+    // Optimized version of line_intersect.
+    // It also computes and returns:
+    //     Ar = A * r
+    //     Av = A * v
+    //
+    // If pos = false:
+    //   returns (min positive lambda, max negative lambda)
+    //
+    // If pos = true:
+    //   returns (min positive lambda, facet index)
+    std::pair<NT, NT> line_intersect(Point const& r,
+                                     Point const& v,
+                                     VT& Ar,
+                                     VT& Av,
+                                     bool pos = false) const
+    {
+        NT lambda = 0;
+        NT min_plus  = std::numeric_limits<NT>::max();
+        NT max_minus = std::numeric_limits<NT>::lowest();
+
+        VT sum_nom;
+        int m = num_of_hyperplanes();
+        int facet = -1;
+
+        Ar.noalias() = A * r.getCoefficients();
+        sum_nom.noalias() = b - Ar;
+        Av.noalias() = A * v.getCoefficients();
+
+        NT* Av_data = Av.data();
+        NT* sum_nom_data = sum_nom.data();
+
+        for (int i = 0; i < m; i++) {
+            if (*Av_data != NT(0)) {
+                lambda = *sum_nom_data / *Av_data;
+
+                if (lambda < min_plus && lambda > NT(0)) {
+                    min_plus = lambda;
+                    if (pos) {
+                        facet = i;
+                    }
+                } else if (lambda > max_minus && lambda < NT(0)) {
+                    max_minus = lambda;
+                }
+            }
+
+            Av_data++;
+            sum_nom_data++;
+        }
+
+        if (pos) {
+            return std::make_pair(min_plus, facet);
+        }
+
+        return std::make_pair(min_plus, max_minus);
+    }
+
+    // Optimized line_intersect version using the previous lambda.
+    // Ar is updated as:
+    //     Ar <- Ar + lambda_prev * Av
+    //
+    // Then Av is recomputed as:
+    //     Av <- A * v
+    std::pair<NT, NT> line_intersect(Point const& r,
+                                     Point const& v,
+                                     VT& Ar,
+                                     VT& Av,
+                                     NT const& lambda_prev,
+                                     bool pos = false) const
+    {   
+        (void)r;  
+        NT lambda = 0;
+        NT min_plus  = std::numeric_limits<NT>::max();
+        NT max_minus = std::numeric_limits<NT>::lowest();
+
+        VT sum_nom;
+        int m = num_of_hyperplanes();
+        int facet = -1;
+
+        Ar.noalias() += lambda_prev * Av;
+        sum_nom.noalias() = b - Ar;
+        Av.noalias() = A * v.getCoefficients();
+
+        NT* sum_nom_data = sum_nom.data();
+        NT* Av_data = Av.data();
+
+        for (int i = 0; i < m; i++) {
+            if (*Av_data != NT(0)) {
+                lambda = *sum_nom_data / *Av_data;
+
+                if (lambda < min_plus && lambda > NT(0)) {
+                    min_plus = lambda;
+                    if (pos) {
+                        facet = i;
+                    }
+                } else if (lambda > max_minus && lambda < NT(0)) {
+                    max_minus = lambda;
+                }
+            }
+
+            Av_data++;
+            sum_nom_data++;
+        }
+
+        if (pos) {
+            return std::make_pair(min_plus, facet);
+        }
+
+        return std::make_pair(min_plus, max_minus);
+    }
+
+        // Compute intersection angles of the great circle
+    // x(lambda) = cos(lambda) * r + sin(lambda) * v
+    // with the simplex boundary A x <= b.
+    //
+    // Input:
+    //   Ar = A * r
+    //   Av = A * v
+    //
+    // Returns:
+    //   first  = smallest positive angle lambda
+    //   second = largest negative angle lambda
+    std::pair<NT, NT> compute_intersections(VT& Ar, VT& Av) const
+    {
+        NT D;
+        NT C1;
+        NT C2;
+        NT eval;
+
+        NT max_root = std::numeric_limits<NT>::lowest();
+        NT min_root = std::numeric_limits<NT>::max();
+
+        NT min_plus  = std::numeric_limits<NT>::max();
+        NT max_minus = std::numeric_limits<NT>::lowest();
+
+        int m = num_of_hyperplanes();
+
+        bool set_negative_root = false;
+        bool set_positive_root = false;
+        bool pos_D = false;
+
+        NT* Av_data = Av.data();
+        NT* Ar_data = Ar.data();
+        const NT* b_data = b.data();
+
+        for (int i = 0; i < m; i++) {
+            D = (*Ar_data) * (*Ar_data)
+              + (*Av_data) * (*Av_data)
+              - (*b_data) * (*b_data);
+
+            if (D > NT(0)) {
+                pos_D = true;
+
+                NT denom = (*Ar_data) * (*Ar_data)
+                         + (*Av_data) * (*Av_data);
+
+                C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * std::sqrt(D))) / denom);
+                C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * std::sqrt(D))) / denom);
+
+                eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C1 = M_PI - C1;
+                }
+
+                if (C1 < min_plus && C1 > NT(0)) {
+                    min_plus = C1;
+                    set_positive_root = true;
+                } else if (C1 > max_minus && C1 < NT(0)) {
+                    max_minus = C1;
+                    set_negative_root = true;
+                }
+
+                if (C1 > max_root && C1 < NT(2) * M_PI) {
+                    max_root = C1;
+                }
+
+                if ((C1 < min_root) && (C1 > (-NT(2) * M_PI))) {
+                    min_root = C1;
+                }
+
+                eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C2 = M_PI - C2;
+                }
+
+                if (C2 < min_plus && C2 > NT(0)) {
+                    min_plus = C2;
+                    set_positive_root = true;
+                } else if (C2 > max_minus && C2 < NT(0)) {
+                    max_minus = C2;
+                    set_negative_root = true;
+                }
+
+                if (C2 > max_root && C2 < NT(2) * M_PI) {
+                    max_root = C2;
+                }
+
+                if (C2 < min_root && C2 > (-NT(2) * M_PI)) {
+                    min_root = C2;
+                }
+            }
+
+            Av_data++;
+            Ar_data++;
+            b_data++;
+        }
+
+        if (!set_negative_root) {
+            if (pos_D) {
+                max_minus = max_root - NT(2) * M_PI;
+            } else {
+                max_minus = NT(0);
+            }
+        }
+
+        if (!set_positive_root) {
+            if (pos_D) {
+                min_plus = min_root + NT(2) * M_PI;
+            } else {
+                min_plus = NT(2) * M_PI;
+            }
+        }
+
+        return std::make_pair(min_plus, max_minus);
+    }
+
+    // Great-circle intersection.
+    // Computes Ar = A*r and Av = A*v, then calls compute_intersections.
+    std::pair<NT, NT> gc_intersect(Point const& r,
+                                   Point const& v,
+                                   VT& Ar,
+                                   VT& Av) const
+    {
+        Ar.noalias() = A * r.getCoefficients();
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections(Ar, Av);
+    }
+
+    // Optimized great-circle intersection using previous lambda.
+    std::pair<NT, NT> gc_intersect(Point const& r,
+                                   Point const& v,
+                                   VT& Ar,
+                                   VT& Av,
+                                   NT const& lambda_prev) const
+    {
+        (void)r;
+
+        Ar.noalias() = std::cos(lambda_prev) * Ar + std::sin(lambda_prev) * Av;
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections(Ar, Av);
+    }
+
+    // Great-circle intersection assuming Ar is already up to date.
+    std::pair<NT, NT> gc_intersect_optimized(Point const& r,
+                                             Point const& v,
+                                             VT& Ar,
+                                             VT& Av,
+                                             NT const& lambda_prev) const
+    {
+        (void)r;
+        (void)lambda_prev;
+
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections(Ar, Av);
+    }
+
+    // Compute the first positive intersection angle of the great circle
+    // x(lambda) = cos(lambda) * r + sin(lambda) * v
+    // with the simplex boundary A x <= b.
+    //
+    // Input:
+    //   Ar = A * r
+    //   Av = A * v
+    //
+    // Returns:
+    //   first  = smallest positive angle lambda
+    //   second = index of the facet hit
+    std::pair<NT, int> compute_intersections_positive(VT const& Ar, VT const& Av) const
+    {
+        NT D;
+        NT C1;
+        NT C2;
+        NT eval;
+        NT min_root = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
+
+        int m = num_of_hyperplanes();
+        int facet = -1;
+        int facet_min = -1;
+
+        bool set_positive_root = false;
+        bool pos_D = false;
+
+        const NT* Av_data = Av.data();
+        const NT* Ar_data = Ar.data();
+        const NT* b_data = b.data();
+
+        for (int i = 0; i < m; i++) {
+            D = (*Ar_data) * (*Ar_data)
+              + (*Av_data) * (*Av_data)
+              - (*b_data) * (*b_data);
+
+            if (D > NT(0)) {
+                pos_D = true;
+
+                NT denom = (*Ar_data) * (*Ar_data)
+                         + (*Av_data) * (*Av_data);
+
+                C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * std::sqrt(D))) / denom);
+                C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * std::sqrt(D))) / denom);
+
+                eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C1 = M_PI - C1;
+                }
+
+                if (C1 < min_plus && C1 > NT(0)) {
+                    min_plus = C1;
+                    set_positive_root = true;
+                    facet = i;
+                }
+
+                if ((C1 < min_root) && (C1 > (-NT(2) * M_PI))) {
+                    min_root = C1;
+                    facet_min = i;
+                }
+
+                eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C2 = M_PI - C2;
+                }
+
+                if (C2 < min_plus && C2 > NT(0)) {
+                    min_plus = C2;
+                    set_positive_root = true;
+                    facet = i;
+                }
+
+                if (C2 < min_root && C2 > (-NT(2) * M_PI)) {
+                    min_root = C2;
+                    facet_min = i;
+                }
+            }
+
+            Av_data++;
+            Ar_data++;
+            b_data++;
+        }
+
+        if (!set_positive_root) {
+            if (pos_D) {
+                min_plus = min_root + NT(2) * M_PI;
+                facet = facet_min;
+            } else {
+                min_plus = NT(2) * M_PI;
+            }
+        }
+
+        return std::make_pair(min_plus, facet);
+    }
+
+    // Great-circle first positive intersection.
+    // Computes Ar = A*r and Av = A*v, then calls compute_intersections_positive.
+    std::pair<NT, int> gc_intersect_positive(Point const& r,
+                                             Point const& v,
+                                             VT& Ar,
+                                             VT& Av) const
+    {
+        Ar.noalias() = A * r.getCoefficients();
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections_positive(Ar, Av);
+    }
+
+    // Optimized great-circle first positive intersection using previous lambda.
+    std::pair<NT, int> gc_intersect_positive(Point const& r,
+                                             Point const& v,
+                                             VT& Ar,
+                                             VT& Av,
+                                             NT const& lambda_prev) const
+    {
+        (void)r;
+
+        Ar.noalias() = std::cos(lambda_prev) * Ar + std::sin(lambda_prev) * Av;
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections_positive(Ar, Av);
+    }
+
+
+        // Compute all intersection roots of the great circle
+    // x(lambda) = cos(lambda) * r + sin(lambda) * v
+    // with the simplex boundary A x <= b.
+    //
+    // Returns:
+    //   first  = negative roots in (-pi, 0)
+    //   second = positive roots in (0, pi)
+    std::pair<VT, VT> compute_intersections_all_roots(VT& Ar, VT& Av) const
+    {
+        std::vector<NT> neg_roots;
+        std::vector<NT> pos_roots;
+
+        int m = num_of_hyperplanes();
+
+        NT* Av_data = Av.data();
+        NT* Ar_data = Ar.data();
+        const NT* b_data = b.data();
+
+        for (int i = 0; i < m; i++) {
+            NT denom = (*Ar_data) * (*Ar_data) + (*Av_data) * (*Av_data);
+            NT D = denom - (*b_data) * (*b_data);
+
+            if (D > NT(0)) {
+                NT sqrtD = std::sqrt(D);
+
+                NT C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * sqrtD)) / denom);
+                NT C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * sqrtD)) / denom);
+
+                NT eval = (*Ar_data) * std::cos(C1)
+                        + (*Av_data) * std::sin(C1)
+                        - (*b_data);
+
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C1 = M_PI - C1;
+                }
+
+                if (C1 > M_PI) {
+                    C1 -= NT(2) * M_PI;
+                } else if (C1 < -M_PI) {
+                    C1 += NT(2) * M_PI;
+                }
+
+                if ((C1 > -M_PI) && (C1 < NT(0))) {
+                    neg_roots.push_back(C1);
+                } else if ((C1 < M_PI) && (C1 > NT(0))) {
+                    pos_roots.push_back(C1);
+                }
+
+                eval = (*Ar_data) * std::cos(C2)
+                     + (*Av_data) * std::sin(C2)
+                     - (*b_data);
+
+                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
+                    C2 = M_PI - C2;
+                }
+
+                if (C2 > M_PI) {
+                    C2 -= NT(2) * M_PI;
+                } else if (C2 < -M_PI) {
+                    C2 += NT(2) * M_PI;
+                }
+
+                if ((C2 > -M_PI) && (C2 < NT(0))) {
+                    neg_roots.push_back(C2);
+                } else if ((C2 < M_PI) && (C2 > NT(0))) {
+                    pos_roots.push_back(C2);
+                }
+            }
+
+            Av_data++;
+            Ar_data++;
+            b_data++;
+        }
+
+        std::sort(neg_roots.begin(), neg_roots.end());
+        std::sort(pos_roots.begin(), pos_roots.end());
+
+        VT neg_roots_vec(neg_roots.size());
+        for (unsigned int i = 0; i < neg_roots.size(); i++) {
+            neg_roots_vec(i) = neg_roots[i];
+        }
+
+        VT pos_roots_vec(pos_roots.size());
+        for (unsigned int i = 0; i < pos_roots.size(); i++) {
+            pos_roots_vec(i) = pos_roots[i];
+        }
+
+        return std::make_pair(neg_roots_vec, pos_roots_vec);
+    }
+
+    // Great-circle all-roots intersection.
+    std::pair<VT, VT> gc_intersect_all_roots(Point const& r,
+                                             Point const& v,
+                                             VT& Ar,
+                                             VT& Av) const
+    {
+        Ar.noalias() = A * r.getCoefficients();
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections_all_roots(Ar, Av);
+    }
+
+    // Optimized great-circle all-roots intersection using previous lambda.
+    std::pair<VT, VT> gc_intersect_all_roots(Point const& r,
+                                             Point const& v,
+                                             VT& Ar,
+                                             VT& Av,
+                                             NT const& lambda_prev) const
+    {
+        (void)r;
+
+        Ar.noalias() = std::cos(lambda_prev) * Ar + std::sin(lambda_prev) * Av;
+        Av.noalias() = A * v.getCoefficients();
+
+        return compute_intersections_all_roots(Ar, Av);
+    }
+
+    // Apply linear transformation T to the simplex inequalities.
+    // If the point transformation is x <- T^{-1} x,
+    // then the H-representation matrix changes as A <- A * T.
+    void linear_transformIt(MT const& T)
+    {
+        A = A * T;
+    }
+
+    // Shift the simplex by a vector c.
+    // For A x <= b, after shifting x <- x + c,
+    // the right-hand side changes as b <- b - A*c.
+    void shift(VT const& c)
+    {
+        b -= A * c;
+    }
+
+    // Reflect tangent direction v at point p on the sphere
+    // against the facet indexed by facet.
+    //
+    // p_p is the tangent-space projector:
+    //     p_p = I - p p^T
+    void compute_reflection(VT& v,
+                            VT const& p,
+                            MT const& p_p,
+                            int const& facet) const
+    {
+        (void)p;
+
+        VT u = p_p * A.row(facet).transpose();
+        u *= (NT(1) / u.norm());
+
+        v += -NT(2) * v.dot(u) * u;
+    }
+
+};
+#endif

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <cmath>
 #include <utility>
+#include <vector>
+#include <algorithm>
 #include <Eigen/Eigen>
 
 /// This class represents the intersection of a simplex with the unit ball.
@@ -131,9 +133,8 @@ public:
 
         // Check ball condition
         VT diff = p_vec - x0;
-        if (diff.squaredNorm() > NT(1) + tol) {
-            return 0;
-        }
+        NT radius_tol = NT(1) + tol;
+        if (diff.squaredNorm() > radius_tol * radius_tol) return 0;
 
         // Check simplex inequalities A p <= b
         VT temp = b - A * p_vec;
@@ -159,7 +160,8 @@ public:
 
         // Ball membership check.
         VT diff = p_vec - x0;
-        if (diff.squaredNorm() > NT(1) + tol) return 0;
+        NT radius_tol = NT(1) + tol;
+        if (diff.squaredNorm() > radius_tol * radius_tol) return 0;
 
         // Update cached A*x along the great-circle rotation:
         // x(lambda) = cos(lambda) * r + sin(lambda) * v.

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -151,10 +151,10 @@ public:
     }
 
     int is_in_optimized(Point const& p,
-                    VT& Ar,
-                    VT& Av,
-                    NT const& lambda_prev,
-                    NT tol = NT(0)) const
+                         VT& Ar,
+                         VT& Av,
+                         NT const& lambda_prev,
+                         NT tol = NT(0)) const
     {
         VT p_vec = p.getCoefficients();
 
@@ -334,7 +334,7 @@ public:
         return std::make_pair(min_plus, max_minus);
     }
 
-        // Compute intersection angles of the great circle
+    // Compute intersection angles of the great circle
     // x(lambda) = cos(lambda) * r + sin(lambda) * v
     // with the simplex boundary A x <= b.
     //

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -36,11 +36,6 @@ public:
         return std::acos(NT(-1));
     }
 
-    static NT trig_tol()
-    {
-        return NT(1e-05);
-    }
-
 private:
     unsigned int _d; // dimension
     MT A;            // matrix A
@@ -48,36 +43,39 @@ private:
     MT V;            // simplex vertices, stored column-wise
     VT x0;           // center of the unit ball
 
-    bool compute_facet_roots(NT const &Ar_i,
-                             NT const &Av_i,
-                             NT const &b_i,
-                             NT &C1,
-                             NT &C2) const
+    bool compute_facet_roots(NT const& Ar_i,
+                            NT const& Av_i,
+                            NT const& b_i,
+                            NT& C1,
+                            NT& C2) const
     {
-        NT denom = Ar_i * Ar_i + Av_i * Av_i;
-        NT D = denom - b_i * b_i;
+        NT const denom =
+            Ar_i * Ar_i + Av_i * Av_i;
+
+        NT const D =
+            denom - b_i * b_i;
 
         if (D <= NT(0))
         {
             return false;
         }
 
-        NT sqrtD = std::sqrt(D);
+        NT const radius =
+            std::sqrt(denom);
 
-        C1 = std::asin((Av_i * b_i + Ar_i * sqrtD) / denom);
-        C2 = std::asin((Av_i * b_i - Ar_i * sqrtD) / denom);
+        NT const phase =
+            std::atan2(Av_i, Ar_i);
 
-        NT eval = Ar_i * std::cos(C1) + Av_i * std::sin(C1) - b_i;
-        if (!(eval > -trig_tol() && eval < trig_tol()))
-        {
-            C1 = pi() - C1;
-        }
+        NT const cosine =
+            std::max(
+                NT(-1),
+                std::min(NT(1), b_i / radius));
 
-        eval = Ar_i * std::cos(C2) + Av_i * std::sin(C2) - b_i;
-        if (!(eval > -trig_tol() && eval < trig_tol()))
-        {
-            C2 = pi() - C2;
-        }
+        NT const offset =
+            std::acos(cosine);
+
+        C1 = phase + offset;
+        C2 = phase - offset;
 
         return true;
     }
@@ -568,37 +566,72 @@ public:
         bool set_positive_root = false;
         bool pos_D = false;
 
+        NT const root_tolerance =
+            NT(64) * std::numeric_limits<NT>::epsilon();
+
         const NT *Av_data = Av.data();
         const NT *Ar_data = Ar.data();
         const NT *b_data = b.data();
 
         for (int i = 0; i < m; i++)
         {
-            if (compute_facet_roots(*Ar_data, *Av_data, *b_data, C1, C2))
+            NT const scale =
+                std::max(
+                    NT(1),
+                    std::max(
+                        std::abs(*Ar_data),
+                        std::max(
+                            std::abs(*Av_data),
+                            std::abs(*b_data))));
+
+            NT const equation_tolerance =
+                NT(128) *
+                std::numeric_limits<NT>::epsilon() *
+                scale;
+
+            // If the current point lies on this facet and the tangent
+            // direction points outside, the collision is immediate.
+            if (std::abs(*Ar_data - *b_data) <=
+                    equation_tolerance &&
+                *Av_data > equation_tolerance)
+            {
+                return std::make_pair(NT(0), i);
+            }
+
+            if (compute_facet_roots(
+                    *Ar_data,
+                    *Av_data,
+                    *b_data,
+                    C1,
+                    C2))
             {
                 pos_D = true;
 
-                if (C1 < min_plus && C1 > NT(0))
+                if (C1 < min_plus &&
+                    C1 > root_tolerance)
                 {
                     min_plus = C1;
                     set_positive_root = true;
                     facet = i;
                 }
 
-                if ((C1 < min_root) && (C1 > (-NT(2) * pi())))
+                if ((C1 < min_root) &&
+                    (C1 > (-NT(2) * pi())))
                 {
                     min_root = C1;
                     facet_min = i;
                 }
 
-                if (C2 < min_plus && C2 > NT(0))
+                if (C2 < min_plus &&
+                    C2 > root_tolerance)
                 {
                     min_plus = C2;
                     set_positive_root = true;
                     facet = i;
                 }
 
-                if (C2 < min_root && C2 > (-NT(2) * pi()))
+                if (C2 < min_root &&
+                    C2 > (-NT(2) * pi()))
                 {
                     min_root = C2;
                     facet_min = i;

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -36,6 +36,11 @@ public:
         return std::acos(NT(-1));
     }
 
+    static NT trig_tol()
+    {
+        return NT(1e-05);
+    }
+
 private:
     unsigned int _d; // dimension
     MT A;            // matrix A
@@ -63,13 +68,13 @@ private:
         C2 = std::asin((Av_i * b_i - Ar_i * sqrtD) / denom);
 
         NT eval = Ar_i * std::cos(C1) + Av_i * std::sin(C1) - b_i;
-        if (!(eval > -NT(1e-05) && eval < NT(1e-05)))
+        if (!(eval > -trig_tol() && eval < trig_tol()))
         {
             C1 = pi() - C1;
         }
 
         eval = Ar_i * std::cos(C2) + Av_i * std::sin(C2) - b_i;
-        if (!(eval > -NT(1e-05) && eval < NT(1e-05)))
+        if (!(eval > -trig_tol() && eval < trig_tol()))
         {
             C2 = pi() - C2;
         }

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -34,6 +34,11 @@ public:
     typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT;
     typedef Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> DenseMT;
 
+        static NT pi()
+    {
+        return std::acos(NT(-1));
+    }
+
 private:
     unsigned int _d;  // dimension
     MT           A;   // matrix A
@@ -384,7 +389,7 @@ public:
 
                 eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = M_PI - C1;
+                    C1 = pi() - C1;
                 }
 
                 if (C1 < min_plus && C1 > NT(0)) {
@@ -395,17 +400,17 @@ public:
                     set_negative_root = true;
                 }
 
-                if (C1 > max_root && C1 < NT(2) * M_PI) {
+                if (C1 > max_root && C1 < NT(2) * pi()) {
                     max_root = C1;
                 }
 
-                if ((C1 < min_root) && (C1 > (-NT(2) * M_PI))) {
+                if ((C1 < min_root) && (C1 > (-NT(2) * pi()))) {
                     min_root = C1;
                 }
 
                 eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = M_PI - C2;
+                    C2 = pi() - C2;
                 }
 
                 if (C2 < min_plus && C2 > NT(0)) {
@@ -416,11 +421,11 @@ public:
                     set_negative_root = true;
                 }
 
-                if (C2 > max_root && C2 < NT(2) * M_PI) {
+                if (C2 > max_root && C2 < NT(2) * pi()) {
                     max_root = C2;
                 }
 
-                if (C2 < min_root && C2 > (-NT(2) * M_PI)) {
+                if (C2 < min_root && C2 > (-NT(2) * pi())) {
                     min_root = C2;
                 }
             }
@@ -432,7 +437,7 @@ public:
 
         if (!set_negative_root) {
             if (pos_D) {
-                max_minus = max_root - NT(2) * M_PI;
+                max_minus = max_root - NT(2) * pi();
             } else {
                 max_minus = NT(0);
             }
@@ -440,9 +445,9 @@ public:
 
         if (!set_positive_root) {
             if (pos_D) {
-                min_plus = min_root + NT(2) * M_PI;
+                min_plus = min_root + NT(2) * pi();
             } else {
-                min_plus = NT(2) * M_PI;
+                min_plus = NT(2) * pi();
             }
         }
 
@@ -539,7 +544,7 @@ public:
 
                 eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = M_PI - C1;
+                    C1 = pi() - C1;
                 }
 
                 if (C1 < min_plus && C1 > NT(0)) {
@@ -548,14 +553,14 @@ public:
                     facet = i;
                 }
 
-                if ((C1 < min_root) && (C1 > (-NT(2) * M_PI))) {
+                if ((C1 < min_root) && (C1 > (-NT(2) * pi()))) {
                     min_root = C1;
                     facet_min = i;
                 }
 
                 eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = M_PI - C2;
+                    C2 = pi() - C2;
                 }
 
                 if (C2 < min_plus && C2 > NT(0)) {
@@ -564,7 +569,7 @@ public:
                     facet = i;
                 }
 
-                if (C2 < min_root && C2 > (-NT(2) * M_PI)) {
+                if (C2 < min_root && C2 > (-NT(2) * pi())) {
                     min_root = C2;
                     facet_min = i;
                 }
@@ -577,10 +582,10 @@ public:
 
         if (!set_positive_root) {
             if (pos_D) {
-                min_plus = min_root + NT(2) * M_PI;
+                min_plus = min_root + NT(2) * pi();
                 facet = facet_min;
             } else {
-                min_plus = NT(2) * M_PI;
+                min_plus = NT(2) * pi();
             }
         }
 
@@ -649,18 +654,18 @@ public:
                         - (*b_data);
 
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = M_PI - C1;
+                    C1 = pi() - C1;
                 }
 
-                if (C1 > M_PI) {
-                    C1 -= NT(2) * M_PI;
-                } else if (C1 < -M_PI) {
-                    C1 += NT(2) * M_PI;
+                if (C1 > pi()) {
+                    C1 -= NT(2) * pi();
+                } else if (C1 < -pi()) {
+                    C1 += NT(2) * pi();
                 }
 
-                if ((C1 > -M_PI) && (C1 < NT(0))) {
+                if ((C1 > -pi()) && (C1 < NT(0))) {
                     neg_roots.push_back(C1);
-                } else if ((C1 < M_PI) && (C1 > NT(0))) {
+                } else if ((C1 < pi()) && (C1 > NT(0))) {
                     pos_roots.push_back(C1);
                 }
 
@@ -669,18 +674,18 @@ public:
                      - (*b_data);
 
                 if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = M_PI - C2;
+                    C2 = pi() - C2;
                 }
 
-                if (C2 > M_PI) {
-                    C2 -= NT(2) * M_PI;
-                } else if (C2 < -M_PI) {
-                    C2 += NT(2) * M_PI;
+                if (C2 > pi()) {
+                    C2 -= NT(2) * pi();
+                } else if (C2 < -pi()) {
+                    C2 += NT(2) * pi();
                 }
 
-                if ((C2 > -M_PI) && (C2 < NT(0))) {
+                if ((C2 > -pi()) && (C2 < NT(0))) {
                     neg_roots.push_back(C2);
-                } else if ((C2 < M_PI) && (C2 > NT(0))) {
+                } else if ((C2 < pi()) && (C2 > NT(0))) {
                     pos_roots.push_back(C2);
                 }
             }

--- a/include/convex_bodies/simplexintersectball.h
+++ b/include/convex_bodies/simplexintersectball.h
@@ -20,43 +20,74 @@
 ///
 /// \tparam Point Point type used by volesti
 /// \tparam MT_type Matrix type for A
-template
-<
+template <
     typename Point,
-    typename MT_type = Eigen::Matrix<typename Point::FT, Eigen::Dynamic, Eigen::Dynamic>
->
-class SimplexIntersectBall {
+    typename MT_type = Eigen::Matrix<typename Point::FT, Eigen::Dynamic, Eigen::Dynamic>>
+class SimplexIntersectBall
+{
 public:
-    typedef Point                                             PointType;
-    typedef typename Point::FT                                NT;
-    typedef MT_type                                           MT;
-    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1>              VT; 
+    typedef Point PointType;
+    typedef typename Point::FT NT;
+    typedef MT_type MT;
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
 
-        static NT pi()
+    static NT pi()
     {
         return std::acos(NT(-1));
     }
 
 private:
-    unsigned int _d;  // dimension
-    MT           A;   // matrix A
-    VT           b;   // vector b, such that A x <= b
-    MT           V;   // simplex vertices, stored column-wise
-    VT           x0;  // center of the unit ball
+    unsigned int _d; // dimension
+    MT A;            // matrix A
+    VT b;            // vector b, such that A x <= b
+    MT V;            // simplex vertices, stored column-wise
+    VT x0;           // center of the unit ball
 
+    bool compute_facet_roots(NT const &Ar_i,
+                             NT const &Av_i,
+                             NT const &b_i,
+                             NT &C1,
+                             NT &C2) const
+    {
+        NT denom = Ar_i * Ar_i + Av_i * Av_i;
+        NT D = denom - b_i * b_i;
+
+        if (D <= NT(0))
+        {
+            return false;
+        }
+
+        NT sqrtD = std::sqrt(D);
+
+        C1 = std::asin((Av_i * b_i + Ar_i * sqrtD) / denom);
+        C2 = std::asin((Av_i * b_i - Ar_i * sqrtD) / denom);
+
+        NT eval = Ar_i * std::cos(C1) + Av_i * std::sin(C1) - b_i;
+        if (!(eval > -NT(1e-05) && eval < NT(1e-05)))
+        {
+            C1 = pi() - C1;
+        }
+
+        eval = Ar_i * std::cos(C2) + Av_i * std::sin(C2) - b_i;
+        if (!(eval > -NT(1e-05) && eval < NT(1e-05)))
+        {
+            C2 = pi() - C2;
+        }
+
+        return true;
+    }
 
 public:
     SimplexIntersectBall() {}
 
     SimplexIntersectBall(unsigned int d_,
-                     MT const& A_,
-                     VT const& b_,
-                     MT const& V_,
-                     VT const& x0_)
-    : _d{d_}, A{A_}, b{b_}, V{V_}, x0{x0_}
+                         MT const &A_,
+                         VT const &b_,
+                         MT const &V_,
+                         VT const &x0_)
+        : _d{d_}, A{A_}, b{b_}, V{V_}, x0{x0_}
     {
     }
-
 
     // Return dimension
     unsigned int dimension() const
@@ -95,25 +126,25 @@ public:
     }
 
     // Change matrix A
-    void set_mat(MT const& A2)
+    void set_mat(MT const &A2)
     {
         A = A2;
     }
 
     // Change vector b
-    void set_vec(VT const& b2)
+    void set_vec(VT const &b2)
     {
         b = b2;
     }
 
     // Change simplex vertices
-    void set_vertices(MT const& V2)
+    void set_vertices(MT const &V2)
     {
         V = V2;
     }
 
     // Change ball center
-    void set_center(VT const& x02)
+    void set_center(VT const &x02)
     {
         x0 = x02;
     }
@@ -121,21 +152,24 @@ public:
     // Check if Point p lies in the simplex-ball intersection:
     //     A p <= b
     //     ||p - x0|| <= 1
-    int is_in(Point const& p, NT tol = NT(0)) const
+    int is_in(Point const &p, NT tol = NT(0)) const
     {
         VT p_vec = p.getCoefficients();
 
         // Check ball condition
         VT diff = p_vec - x0;
         NT radius_tol = NT(1) + tol;
-        if (diff.squaredNorm() > radius_tol * radius_tol) return 0;
+        if (diff.squaredNorm() > radius_tol * radius_tol)
+            return 0;
 
         // Check simplex inequalities A p <= b
         VT temp = b - A * p_vec;
-        const NT* Ax_b_data = temp.data();
+        const NT *Ax_b_data = temp.data();
 
-        for (int i = 0; i < A.rows(); i++) {
-            if ((*Ax_b_data) < NT(-tol)) {
+        for (int i = 0; i < A.rows(); i++)
+        {
+            if ((*Ax_b_data) < NT(-tol))
+            {
                 return 0;
             }
             Ax_b_data++;
@@ -144,18 +178,19 @@ public:
         return -1;
     }
 
-    int is_in_optimized(Point const& p,
-                         VT& Ar,
-                         VT& Av,
-                         NT const& lambda_prev,
-                         NT tol = NT(0)) const
+    int is_in_optimized(Point const &p,
+                        VT &Ar,
+                        VT &Av,
+                        NT const &lambda_prev,
+                        NT tol = NT(0)) const
     {
         VT p_vec = p.getCoefficients();
 
         // Ball membership check.
         VT diff = p_vec - x0;
         NT radius_tol = NT(1) + tol;
-        if (diff.squaredNorm() > radius_tol * radius_tol) return 0;
+        if (diff.squaredNorm() > radius_tol * radius_tol)
+            return 0;
 
         // Update cached A*x along the great-circle rotation:
         // x(lambda) = cos(lambda) * r + sin(lambda) * v.
@@ -164,16 +199,17 @@ public:
         Ar.noalias() = std::cos(lambda_prev) * Ar + std::sin(lambda_prev) * Av;
 
         VT temp = b - Ar;
-        const NT* Ax_b_data = temp.data();
+        const NT *Ax_b_data = temp.data();
 
-        for (int i = 0; i < A.rows(); i++) {
-            if ((*Ax_b_data) < NT(-tol)) return 0;
+        for (int i = 0; i < A.rows(); i++)
+        {
+            if ((*Ax_b_data) < NT(-tol))
+                return 0;
             Ax_b_data++;
         }
 
         return -1;
     }
-
 
     // Compute intersection parameters of the line r + lambda * v
     // with the simplex A x <= b.
@@ -181,10 +217,10 @@ public:
     // Returns:
     //   first  = smallest positive lambda
     //   second = largest negative lambda
-    std::pair<NT, NT> line_intersect(Point const& r, Point const& v) const
+    std::pair<NT, NT> line_intersect(Point const &r, Point const &v) const
     {
         NT lambda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         VT sum_nom;
@@ -195,18 +231,22 @@ public:
         sum_nom.noalias() = b - A * r.getCoefficients();
         sum_denom.noalias() = A * v.getCoefficients();
 
-        NT* sum_nom_data = sum_nom.data();
-        NT* sum_denom_data = sum_denom.data();
+        NT *sum_nom_data = sum_nom.data();
+        NT *sum_denom_data = sum_denom.data();
 
-        for (int i = 0; i < m; i++) {
-            if (*sum_denom_data != NT(0)) {
+        for (int i = 0; i < m; i++)
+        {
+            if (*sum_denom_data != NT(0))
+            {
                 lambda = *sum_nom_data / *sum_denom_data;
 
-                if (lambda < min_plus && lambda > NT(0)) {
+                if (lambda < min_plus && lambda > NT(0))
+                {
                     min_plus = lambda;
                 }
 
-                if (lambda > max_minus && lambda < NT(0)) {
+                if (lambda > max_minus && lambda < NT(0))
+                {
                     max_minus = lambda;
                 }
             }
@@ -228,14 +268,14 @@ public:
     //
     // If pos = true:
     //   returns (min positive lambda, facet index)
-    std::pair<NT, NT> line_intersect(Point const& r,
-                                     Point const& v,
-                                     VT& Ar,
-                                     VT& Av,
+    std::pair<NT, NT> line_intersect(Point const &r,
+                                     Point const &v,
+                                     VT &Ar,
+                                     VT &Av,
                                      bool pos = false) const
     {
         NT lambda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         VT sum_nom;
@@ -246,19 +286,25 @@ public:
         sum_nom.noalias() = b - Ar;
         Av.noalias() = A * v.getCoefficients();
 
-        NT* Av_data = Av.data();
-        NT* sum_nom_data = sum_nom.data();
+        NT *Av_data = Av.data();
+        NT *sum_nom_data = sum_nom.data();
 
-        for (int i = 0; i < m; i++) {
-            if (*Av_data != NT(0)) {
+        for (int i = 0; i < m; i++)
+        {
+            if (*Av_data != NT(0))
+            {
                 lambda = *sum_nom_data / *Av_data;
 
-                if (lambda < min_plus && lambda > NT(0)) {
+                if (lambda < min_plus && lambda > NT(0))
+                {
                     min_plus = lambda;
-                    if (pos) {
+                    if (pos)
+                    {
                         facet = i;
                     }
-                } else if (lambda > max_minus && lambda < NT(0)) {
+                }
+                else if (lambda > max_minus && lambda < NT(0))
+                {
                     max_minus = lambda;
                 }
             }
@@ -267,7 +313,8 @@ public:
             sum_nom_data++;
         }
 
-        if (pos) {
+        if (pos)
+        {
             return std::make_pair(min_plus, facet);
         }
 
@@ -280,16 +327,16 @@ public:
     //
     // Then Av is recomputed as:
     //     Av <- A * v
-    std::pair<NT, NT> line_intersect(Point const& r,
-                                     Point const& v,
-                                     VT& Ar,
-                                     VT& Av,
-                                     NT const& lambda_prev,
+    std::pair<NT, NT> line_intersect(Point const &r,
+                                     Point const &v,
+                                     VT &Ar,
+                                     VT &Av,
+                                     NT const &lambda_prev,
                                      bool pos = false) const
-    {   
-        (void)r;  
+    {
+        (void)r;
         NT lambda = 0;
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         VT sum_nom;
@@ -300,19 +347,25 @@ public:
         sum_nom.noalias() = b - Ar;
         Av.noalias() = A * v.getCoefficients();
 
-        NT* sum_nom_data = sum_nom.data();
-        NT* Av_data = Av.data();
+        NT *sum_nom_data = sum_nom.data();
+        NT *Av_data = Av.data();
 
-        for (int i = 0; i < m; i++) {
-            if (*Av_data != NT(0)) {
+        for (int i = 0; i < m; i++)
+        {
+            if (*Av_data != NT(0))
+            {
                 lambda = *sum_nom_data / *Av_data;
 
-                if (lambda < min_plus && lambda > NT(0)) {
+                if (lambda < min_plus && lambda > NT(0))
+                {
                     min_plus = lambda;
-                    if (pos) {
+                    if (pos)
+                    {
                         facet = i;
                     }
-                } else if (lambda > max_minus && lambda < NT(0)) {
+                }
+                else if (lambda > max_minus && lambda < NT(0))
+                {
                     max_minus = lambda;
                 }
             }
@@ -321,7 +374,8 @@ public:
             sum_nom_data++;
         }
 
-        if (pos) {
+        if (pos)
+        {
             return std::make_pair(min_plus, facet);
         }
 
@@ -339,17 +393,15 @@ public:
     // Returns:
     //   first  = smallest positive angle lambda
     //   second = largest negative angle lambda
-    std::pair<NT, NT> compute_intersections(VT& Ar, VT& Av) const
+    std::pair<NT, NT> compute_intersections(VT &Ar, VT &Av) const
     {
-        NT D;
         NT C1;
         NT C2;
-        NT eval;
 
         NT max_root = std::numeric_limits<NT>::lowest();
         NT min_root = std::numeric_limits<NT>::max();
 
-        NT min_plus  = std::numeric_limits<NT>::max();
+        NT min_plus = std::numeric_limits<NT>::max();
         NT max_minus = std::numeric_limits<NT>::lowest();
 
         int m = num_of_hyperplanes();
@@ -358,63 +410,55 @@ public:
         bool set_positive_root = false;
         bool pos_D = false;
 
-        NT* Av_data = Av.data();
-        NT* Ar_data = Ar.data();
-        const NT* b_data = b.data();
+        NT *Av_data = Av.data();
+        NT *Ar_data = Ar.data();
+        const NT *b_data = b.data();
 
-        for (int i = 0; i < m; i++) {
-            D = (*Ar_data) * (*Ar_data)
-              + (*Av_data) * (*Av_data)
-              - (*b_data) * (*b_data);
-
-            if (D > NT(0)) {
+        for (int i = 0; i < m; i++)
+        {
+            if (compute_facet_roots(*Ar_data, *Av_data, *b_data, C1, C2))
+            {
                 pos_D = true;
 
-                NT denom = (*Ar_data) * (*Ar_data)
-                         + (*Av_data) * (*Av_data);
-
-                C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * std::sqrt(D))) / denom);
-                C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * std::sqrt(D))) / denom);
-
-                eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = pi() - C1;
-                }
-
-                if (C1 < min_plus && C1 > NT(0)) {
+                if (C1 < min_plus && C1 > NT(0))
+                {
                     min_plus = C1;
                     set_positive_root = true;
-                } else if (C1 > max_minus && C1 < NT(0)) {
+                }
+                else if (C1 > max_minus && C1 < NT(0))
+                {
                     max_minus = C1;
                     set_negative_root = true;
                 }
 
-                if (C1 > max_root && C1 < NT(2) * pi()) {
+                if (C1 > max_root && C1 < NT(2) * pi())
+                {
                     max_root = C1;
                 }
 
-                if ((C1 < min_root) && (C1 > (-NT(2) * pi()))) {
+                if ((C1 < min_root) && (C1 > (-NT(2) * pi())))
+                {
                     min_root = C1;
                 }
 
-                eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = pi() - C2;
-                }
-
-                if (C2 < min_plus && C2 > NT(0)) {
+                if (C2 < min_plus && C2 > NT(0))
+                {
                     min_plus = C2;
                     set_positive_root = true;
-                } else if (C2 > max_minus && C2 < NT(0)) {
+                }
+                else if (C2 > max_minus && C2 < NT(0))
+                {
                     max_minus = C2;
                     set_negative_root = true;
                 }
 
-                if (C2 > max_root && C2 < NT(2) * pi()) {
+                if (C2 > max_root && C2 < NT(2) * pi())
+                {
                     max_root = C2;
                 }
 
-                if (C2 < min_root && C2 > (-NT(2) * pi())) {
+                if (C2 < min_root && C2 > (-NT(2) * pi()))
+                {
                     min_root = C2;
                 }
             }
@@ -424,18 +468,26 @@ public:
             b_data++;
         }
 
-        if (!set_negative_root) {
-            if (pos_D) {
+        if (!set_negative_root)
+        {
+            if (pos_D)
+            {
                 max_minus = max_root - NT(2) * pi();
-            } else {
+            }
+            else
+            {
                 max_minus = NT(0);
             }
         }
 
-        if (!set_positive_root) {
-            if (pos_D) {
+        if (!set_positive_root)
+        {
+            if (pos_D)
+            {
                 min_plus = min_root + NT(2) * pi();
-            } else {
+            }
+            else
+            {
                 min_plus = NT(2) * pi();
             }
         }
@@ -445,10 +497,10 @@ public:
 
     // Great-circle intersection.
     // Computes Ar = A*r and Av = A*v, then calls compute_intersections.
-    std::pair<NT, NT> gc_intersect(Point const& r,
-                                   Point const& v,
-                                   VT& Ar,
-                                   VT& Av) const
+    std::pair<NT, NT> gc_intersect(Point const &r,
+                                   Point const &v,
+                                   VT &Ar,
+                                   VT &Av) const
     {
         Ar.noalias() = A * r.getCoefficients();
         Av.noalias() = A * v.getCoefficients();
@@ -457,11 +509,11 @@ public:
     }
 
     // Optimized great-circle intersection using previous lambda.
-    std::pair<NT, NT> gc_intersect(Point const& r,
-                                   Point const& v,
-                                   VT& Ar,
-                                   VT& Av,
-                                   NT const& lambda_prev) const
+    std::pair<NT, NT> gc_intersect(Point const &r,
+                                   Point const &v,
+                                   VT &Ar,
+                                   VT &Av,
+                                   NT const &lambda_prev) const
     {
         (void)r;
 
@@ -472,11 +524,11 @@ public:
     }
 
     // Great-circle intersection assuming Ar is already up to date.
-    std::pair<NT, NT> gc_intersect_optimized(Point const& r,
-                                             Point const& v,
-                                             VT& Ar,
-                                             VT& Av,
-                                             NT const& lambda_prev) const
+    std::pair<NT, NT> gc_intersect_optimized(Point const &r,
+                                             Point const &v,
+                                             VT &Ar,
+                                             VT &Av,
+                                             NT const &lambda_prev) const
     {
         (void)r;
         (void)lambda_prev;
@@ -497,12 +549,10 @@ public:
     // Returns:
     //   first  = smallest positive angle lambda
     //   second = index of the facet hit
-    std::pair<NT, int> compute_intersections_positive(VT const& Ar, VT const& Av) const
+    std::pair<NT, int> compute_intersections_positive(VT const &Ar, VT const &Av) const
     {
-        NT D;
         NT C1;
         NT C2;
-        NT eval;
         NT min_root = std::numeric_limits<NT>::max();
         NT min_plus = std::numeric_limits<NT>::max();
 
@@ -513,52 +563,38 @@ public:
         bool set_positive_root = false;
         bool pos_D = false;
 
-        const NT* Av_data = Av.data();
-        const NT* Ar_data = Ar.data();
-        const NT* b_data = b.data();
+        const NT *Av_data = Av.data();
+        const NT *Ar_data = Ar.data();
+        const NT *b_data = b.data();
 
-        for (int i = 0; i < m; i++) {
-            D = (*Ar_data) * (*Ar_data)
-              + (*Av_data) * (*Av_data)
-              - (*b_data) * (*b_data);
-
-            if (D > NT(0)) {
+        for (int i = 0; i < m; i++)
+        {
+            if (compute_facet_roots(*Ar_data, *Av_data, *b_data, C1, C2))
+            {
                 pos_D = true;
 
-                NT denom = (*Ar_data) * (*Ar_data)
-                         + (*Av_data) * (*Av_data);
-
-                C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * std::sqrt(D))) / denom);
-                C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * std::sqrt(D))) / denom);
-
-                eval = (*Ar_data) * std::cos(C1) + (*Av_data) * std::sin(C1) - (*b_data);
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = pi() - C1;
-                }
-
-                if (C1 < min_plus && C1 > NT(0)) {
+                if (C1 < min_plus && C1 > NT(0))
+                {
                     min_plus = C1;
                     set_positive_root = true;
                     facet = i;
                 }
 
-                if ((C1 < min_root) && (C1 > (-NT(2) * pi()))) {
+                if ((C1 < min_root) && (C1 > (-NT(2) * pi())))
+                {
                     min_root = C1;
                     facet_min = i;
                 }
 
-                eval = (*Ar_data) * std::cos(C2) + (*Av_data) * std::sin(C2) - (*b_data);
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = pi() - C2;
-                }
-
-                if (C2 < min_plus && C2 > NT(0)) {
+                if (C2 < min_plus && C2 > NT(0))
+                {
                     min_plus = C2;
                     set_positive_root = true;
                     facet = i;
                 }
 
-                if (C2 < min_root && C2 > (-NT(2) * pi())) {
+                if (C2 < min_root && C2 > (-NT(2) * pi()))
+                {
                     min_root = C2;
                     facet_min = i;
                 }
@@ -569,11 +605,15 @@ public:
             b_data++;
         }
 
-        if (!set_positive_root) {
-            if (pos_D) {
+        if (!set_positive_root)
+        {
+            if (pos_D)
+            {
                 min_plus = min_root + NT(2) * pi();
                 facet = facet_min;
-            } else {
+            }
+            else
+            {
                 min_plus = NT(2) * pi();
             }
         }
@@ -583,10 +623,10 @@ public:
 
     // Great-circle first positive intersection.
     // Computes Ar = A*r and Av = A*v, then calls compute_intersections_positive.
-    std::pair<NT, int> gc_intersect_positive(Point const& r,
-                                             Point const& v,
-                                             VT& Ar,
-                                             VT& Av) const
+    std::pair<NT, int> gc_intersect_positive(Point const &r,
+                                             Point const &v,
+                                             VT &Ar,
+                                             VT &Av) const
     {
         Ar.noalias() = A * r.getCoefficients();
         Av.noalias() = A * v.getCoefficients();
@@ -595,11 +635,11 @@ public:
     }
 
     // Optimized great-circle first positive intersection using previous lambda.
-    std::pair<NT, int> gc_intersect_positive(Point const& r,
-                                             Point const& v,
-                                             VT& Ar,
-                                             VT& Av,
-                                             NT const& lambda_prev) const
+    std::pair<NT, int> gc_intersect_positive(Point const &r,
+                                             Point const &v,
+                                             VT &Ar,
+                                             VT &Av,
+                                             NT const &lambda_prev) const
     {
         (void)r;
 
@@ -609,7 +649,6 @@ public:
         return compute_intersections_positive(Ar, Av);
     }
 
-
     // Compute all intersection roots of the great circle
     // x(lambda) = cos(lambda) * r + sin(lambda) * v
     // with the simplex boundary A x <= b.
@@ -617,68 +656,60 @@ public:
     // Returns:
     //   first  = negative roots in (-pi, 0)
     //   second = positive roots in (0, pi)
-    std::pair<VT, VT> compute_intersections_all_roots(VT& Ar, VT& Av) const
+    std::pair<VT, VT> compute_intersections_all_roots(VT &Ar, VT &Av) const
     {
         std::vector<NT> neg_roots;
         std::vector<NT> pos_roots;
 
         int m = num_of_hyperplanes();
 
-        NT* Av_data = Av.data();
-        NT* Ar_data = Ar.data();
-        const NT* b_data = b.data();
+        NT *Av_data = Av.data();
+        NT *Ar_data = Ar.data();
+        const NT *b_data = b.data();
 
-        for (int i = 0; i < m; i++) {
-            NT denom = (*Ar_data) * (*Ar_data) + (*Av_data) * (*Av_data);
-            NT D = denom - (*b_data) * (*b_data);
+        for (int i = 0; i < m; i++)
+        {
+            NT C1;
+            NT C2;
 
-            if (D > NT(0)) {
-                NT sqrtD = std::sqrt(D);
-
-                NT C1 = std::asin((((*Av_data) * (*b_data)) + ((*Ar_data) * sqrtD)) / denom);
-                NT C2 = std::asin((((*Av_data) * (*b_data)) - ((*Ar_data) * sqrtD)) / denom);
-
-                NT eval = (*Ar_data) * std::cos(C1)
-                        + (*Av_data) * std::sin(C1)
-                        - (*b_data);
-
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C1 = pi() - C1;
-                }
-
-                if (C1 > pi()) {
+            if (compute_facet_roots(*Ar_data, *Av_data, *b_data, C1, C2))
+            {
+                if (C1 > pi())
+                {
                     C1 -= NT(2) * pi();
-                } else if (C1 < -pi()) {
+                }
+                else if (C1 < -pi())
+                {
                     C1 += NT(2) * pi();
                 }
 
-                if ((C1 > -pi()) && (C1 < NT(0))) {
+                if ((C1 > -pi()) && (C1 < NT(0)))
+                {
                     neg_roots.push_back(C1);
-                } else if ((C1 < pi()) && (C1 > NT(0))) {
+                }
+                else if ((C1 < pi()) && (C1 > NT(0)))
+                {
                     pos_roots.push_back(C1);
                 }
 
-                eval = (*Ar_data) * std::cos(C2)
-                     + (*Av_data) * std::sin(C2)
-                     - (*b_data);
-
-                if (!(eval > -NT(1e-05) && eval < NT(1e-05))) {
-                    C2 = pi() - C2;
-                }
-
-                if (C2 > pi()) {
+                if (C2 > pi())
+                {
                     C2 -= NT(2) * pi();
-                } else if (C2 < -pi()) {
+                }
+                else if (C2 < -pi())
+                {
                     C2 += NT(2) * pi();
                 }
 
-                if ((C2 > -pi()) && (C2 < NT(0))) {
+                if ((C2 > -pi()) && (C2 < NT(0)))
+                {
                     neg_roots.push_back(C2);
-                } else if ((C2 < pi()) && (C2 > NT(0))) {
+                }
+                else if ((C2 < pi()) && (C2 > NT(0)))
+                {
                     pos_roots.push_back(C2);
                 }
             }
-
             Av_data++;
             Ar_data++;
             b_data++;
@@ -688,12 +719,14 @@ public:
         std::sort(pos_roots.begin(), pos_roots.end());
 
         VT neg_roots_vec(neg_roots.size());
-        for (unsigned int i = 0; i < neg_roots.size(); i++) {
+        for (unsigned int i = 0; i < neg_roots.size(); i++)
+        {
             neg_roots_vec(i) = neg_roots[i];
         }
 
         VT pos_roots_vec(pos_roots.size());
-        for (unsigned int i = 0; i < pos_roots.size(); i++) {
+        for (unsigned int i = 0; i < pos_roots.size(); i++)
+        {
             pos_roots_vec(i) = pos_roots[i];
         }
 
@@ -701,10 +734,10 @@ public:
     }
 
     // Great-circle all-roots intersection.
-    std::pair<VT, VT> gc_intersect_all_roots(Point const& r,
-                                             Point const& v,
-                                             VT& Ar,
-                                             VT& Av) const
+    std::pair<VT, VT> gc_intersect_all_roots(Point const &r,
+                                             Point const &v,
+                                             VT &Ar,
+                                             VT &Av) const
     {
         Ar.noalias() = A * r.getCoefficients();
         Av.noalias() = A * v.getCoefficients();
@@ -713,11 +746,11 @@ public:
     }
 
     // Optimized great-circle all-roots intersection using previous lambda.
-    std::pair<VT, VT> gc_intersect_all_roots(Point const& r,
-                                             Point const& v,
-                                             VT& Ar,
-                                             VT& Av,
-                                             NT const& lambda_prev) const
+    std::pair<VT, VT> gc_intersect_all_roots(Point const &r,
+                                             Point const &v,
+                                             VT &Ar,
+                                             VT &Av,
+                                             NT const &lambda_prev) const
     {
         (void)r;
 
@@ -730,7 +763,7 @@ public:
     // Apply linear transformation T to the simplex inequalities.
     // If the point transformation is x <- T^{-1} x,
     // then the H-representation matrix changes as A <- A * T.
-    void linear_transformIt(MT const& T)
+    void linear_transformIt(MT const &T)
     {
         A = A * T;
     }
@@ -738,7 +771,7 @@ public:
     // Shift the simplex by a vector c.
     // For A x <= b, after shifting x <- x + c,
     // the right-hand side changes as b <- b - A*c.
-    void shift(VT const& c)
+    void shift(VT const &c)
     {
         b -= A * c;
     }
@@ -748,10 +781,10 @@ public:
     //
     // p_p is the tangent-space projector:
     //     p_p = I - p p^T
-    void compute_reflection(VT& v,
-                            VT const& p,
-                            MT const& p_p,
-                            int const& facet) const
+    void compute_reflection(VT &v,
+                            VT const &p,
+                            MT const &p_p,
+                            int const &facet) const
     {
         (void)p;
 
@@ -760,6 +793,5 @@ public:
 
         v += -NT(2) * v.dot(u) * u;
     }
-
 };
 #endif

--- a/include/convex_bodies/simplexintersectball_components.h
+++ b/include/convex_bodies/simplexintersectball_components.h
@@ -1,0 +1,50 @@
+#ifndef SIMPLEXINTERSECTBALL_COMPONENTS_H
+#define SIMPLEXINTERSECTBALL_COMPONENTS_H
+
+#include <cmath>
+#include <Eigen/Eigen>
+
+template <typename NT>
+bool segment_intersects_ball(
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& u,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& v,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+
+    VT direction = v - u;
+    VT shifted = u - center;
+
+    NT a = direction.dot(direction);
+    NT b = NT(2) * shifted.dot(direction);
+    NT c = shifted.dot(shifted) - radius * radius;
+
+    if (a <= tol)
+    {
+        return c <= tol;
+    }
+
+    NT discriminant = b * b - NT(4) * a * c;
+
+    if (discriminant < -tol)
+    {
+        return false;
+    }
+
+    if (discriminant < NT(0))
+    {
+        discriminant = NT(0);
+    }
+
+    NT sqrt_discriminant = std::sqrt(discriminant);
+
+    NT t1 = (-b - sqrt_discriminant) / (NT(2) * a);
+    NT t2 = (-b + sqrt_discriminant) / (NT(2) * a);
+
+    return (t1 >= -tol && t1 <= NT(1) + tol) ||
+           (t2 >= -tol && t2 <= NT(1) + tol);
+}
+
+#endif

--- a/include/convex_bodies/simplexintersectball_components.h
+++ b/include/convex_bodies/simplexintersectball_components.h
@@ -47,4 +47,14 @@ bool segment_intersects_ball(
            (t2 >= -tol && t2 <= NT(1) + tol);
 }
 
+template <typename NT>
+bool point_is_inside_ball(
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& p,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    return (p - center).squaredNorm() < radius * radius - tol;
+}
+
 #endif

--- a/include/convex_bodies/simplexintersectball_components.h
+++ b/include/convex_bodies/simplexintersectball_components.h
@@ -168,4 +168,17 @@ inline std::vector<std::vector<int>> connected_components_from_graph(
     return components;
 }
 
+template <typename NT>
+std::vector<std::vector<int>> find_simplex_ball_components(
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& vertices,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> adjacency =
+        build_simplex_ball_graph(vertices, center, radius, tol);
+
+    return connected_components_from_graph(adjacency);
+}
+
 #endif

--- a/include/convex_bodies/simplexintersectball_components.h
+++ b/include/convex_bodies/simplexintersectball_components.h
@@ -57,4 +57,50 @@ bool point_is_inside_ball(
     return (p - center).squaredNorm() < radius * radius - tol;
 }
 
+template <typename NT>
+Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> build_simplex_ball_graph(
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& vertices,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+
+    int n = vertices.cols();
+
+    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> adjacency =
+        Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic>::Ones(n, n);
+
+    for (int i = 0; i < n; ++i)
+    {
+        adjacency(i, i) = 0;
+    }
+
+    for (int i = 0; i < n; ++i)
+    {
+        VT vi = vertices.col(i);
+
+        if (point_is_inside_ball(vi, center, radius, tol))
+        {
+            adjacency.row(i).setZero();
+            adjacency.col(i).setZero();
+            continue;
+        }
+
+        for (int j = i + 1; j < n; ++j)
+        {
+            VT vj = vertices.col(j);
+
+            if (point_is_inside_ball(vj, center, radius, tol) ||
+                segment_intersects_ball(vi, vj, center, radius, tol))
+            {
+                adjacency(i, j) = 0;
+                adjacency(j, i) = 0;
+            }
+        }
+    }
+
+    return adjacency;
+}
+
 #endif

--- a/include/convex_bodies/simplexintersectball_components.h
+++ b/include/convex_bodies/simplexintersectball_components.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <vector>
 #include <queue>
+#include <utility>
 #include <Eigen/Eigen>
 
 template <typename NT>
@@ -199,6 +200,86 @@ Eigen::Matrix<NT, Eigen::Dynamic, 1> radial_starting_point_from_vertex(
     }
 
     return center + radius * direction / norm;
+}
+
+template <typename NT>
+bool point_satisfies_halfspaces(
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& A,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& b,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& p,
+    NT tol = NT(1e-10))
+{
+    for (int i = 0; i < A.rows(); ++i)
+    {
+        if (A.row(i).dot(p) > b(i) + tol)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+template <typename NT>
+std::pair<bool, Eigen::Matrix<NT, Eigen::Dynamic, 1>>
+find_starting_point_for_component(
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& vertices,
+    std::vector<int> const& component,
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& A,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& b,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+
+    for (int vertex_index : component)
+    {
+        VT vertex = vertices.col(vertex_index);
+        VT candidate = radial_starting_point_from_vertex(vertex, center, radius, tol);
+
+        bool on_sphere =
+            std::abs((candidate - center).norm() - radius) <= NT(100) * tol;
+
+        if (on_sphere && point_satisfies_halfspaces(A, b, candidate, tol))
+        {
+            return std::make_pair(true, candidate);
+        }
+    }
+
+    VT empty(center.rows());
+    empty.setZero();
+
+    return std::make_pair(false, empty);
+}
+
+template <typename NT>
+std::vector<Eigen::Matrix<NT, Eigen::Dynamic, 1>>
+find_starting_points_for_components(
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& vertices,
+    std::vector<std::vector<int>> const& components,
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& A,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& b,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+
+    std::vector<VT> starting_points;
+
+    for (std::vector<int> const& component : components)
+    {
+        std::pair<bool, VT> result =
+            find_starting_point_for_component(vertices, component, A, b, center, radius, tol);
+
+        if (result.first)
+        {
+            starting_points.push_back(result.second);
+        }
+    }
+
+    return starting_points;
 }
 
 #endif

--- a/include/convex_bodies/simplexintersectball_components.h
+++ b/include/convex_bodies/simplexintersectball_components.h
@@ -282,4 +282,25 @@ find_starting_points_for_components(
     return starting_points;
 }
 
+template <typename NT>
+std::pair<
+    std::vector<std::vector<int>>,
+    std::vector<Eigen::Matrix<NT, Eigen::Dynamic, 1>>>
+find_simplex_ball_components_and_starting_points(
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& vertices,
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& A,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& b,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    std::vector<std::vector<int>> components =
+        find_simplex_ball_components(vertices, center, radius, tol);
+
+    std::vector<Eigen::Matrix<NT, Eigen::Dynamic, 1>> starting_points =
+        find_starting_points_for_components(vertices, components, A, b, center, radius, tol);
+
+    return std::make_pair(components, starting_points);
+}
+
 #endif

--- a/include/convex_bodies/simplexintersectball_components.h
+++ b/include/convex_bodies/simplexintersectball_components.h
@@ -181,4 +181,24 @@ std::vector<std::vector<int>> find_simplex_ball_components(
     return connected_components_from_graph(adjacency);
 }
 
+template <typename NT>
+Eigen::Matrix<NT, Eigen::Dynamic, 1> radial_starting_point_from_vertex(
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& vertex,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+
+    VT direction = vertex - center;
+    NT norm = direction.norm();
+
+    if (norm <= tol)
+    {
+        return center;
+    }
+
+    return center + radius * direction / norm;
+}
+
 #endif

--- a/include/convex_bodies/simplexintersectball_components.h
+++ b/include/convex_bodies/simplexintersectball_components.h
@@ -2,34 +2,36 @@
 #define SIMPLEXINTERSECTBALL_COMPONENTS_H
 
 #include <cmath>
+#include <cstdlib>
 #include <queue>
 #include <utility>
 #include <vector>
 
 #include <Eigen/Eigen>
 
-/// Returns true if the segment [u, v] intersects the ball B(center, radius).
-template <typename NT>
-bool segment_intersects_ball(
-    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& u,
-    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& v,
-    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
-    NT radius = NT(1),
-    NT tol = NT(1e-10))
-{
-    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+#undef Realloc
+#undef Free
+#include "lp_lib.h"
 
-    VT direction = v - u;
-    VT shifted = u - center;
+
+/// Solves ||point + t * direction - center||^2 = radius^2.
+/// Returns false if the line does not intersect the sphere.
+/// Precondition: direction.dot(direction) > tol.
+template <typename NT>
+bool solve_ball_line_roots(
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& point,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& direction,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius,
+    NT tol,
+    NT& tmin,
+    NT& tmax)
+{
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> shifted = point - center;
 
     NT a = direction.dot(direction);
     NT b = NT(2) * shifted.dot(direction);
     NT c = shifted.dot(shifted) - radius * radius;
-
-    if (a <= tol)
-    {
-        return c <= tol;
-    }
 
     NT discriminant = b * b - NT(4) * a * c;
 
@@ -45,11 +47,38 @@ bool segment_intersects_ball(
 
     NT sqrt_discriminant = std::sqrt(discriminant);
 
-    NT t1 = (-b - sqrt_discriminant) / (NT(2) * a);
-    NT t2 = (-b + sqrt_discriminant) / (NT(2) * a);
+    tmin = (-b - sqrt_discriminant) / (NT(2) * a);
+    tmax = (-b + sqrt_discriminant) / (NT(2) * a);
 
-    return (t1 >= -tol && t1 <= NT(1) + tol) ||
-           (t2 >= -tol && t2 <= NT(1) + tol);
+    return true;
+}
+
+/// Tests whether a segment intersects a Euclidean ball.
+template <typename NT>
+bool segment_intersects_ball(
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& u,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& v,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> direction = v - u;
+
+    if (direction.dot(direction) <= tol)
+    {
+        return (u - center).squaredNorm() <= radius * radius + tol;
+    }
+
+    NT tmin;
+    NT tmax;
+
+    if (!solve_ball_line_roots(u, direction, center, radius, tol, tmin, tmax))
+    {
+        return false;
+    }
+
+    return (tmin >= -tol && tmin <= NT(1) + tol) ||
+           (tmax >= -tol && tmax <= NT(1) + tol);
 }
 
 /// Returns true if p lies strictly inside the ball B(center, radius).
@@ -183,16 +212,6 @@ inline std::vector<std::vector<int>> connected_components_from_graph(
     return components;
 }
 
-/// Finds connected components of adjacency, treating all vertices as active.
-inline std::vector<std::vector<int>> connected_components_from_graph(
-    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> const& adjacency)
-{
-    int n = adjacency.rows();
-
-    std::vector<int> active(n, 1);
-
-    return connected_components_from_graph(adjacency, active);
-}
 
 /// Finds connected components of the simplex-sphere intersection.
 template <typename NT>
@@ -223,59 +242,188 @@ ray_sphere_intersection_from_interior(
 {
     typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
 
+    VT empty = VT::Zero(center.rows());
     VT direction = vertex - interior_point;
-    VT shifted = interior_point - center;
 
-    NT a = direction.dot(direction);
-    NT b = NT(2) * shifted.dot(direction);
-    NT c = shifted.dot(shifted) - radius * radius;
-
-    if (a <= tol)
+    if (direction.dot(direction) <= tol)
     {
-        VT empty(center.rows());
-        empty.setZero();
-
         return std::make_pair(false, empty);
     }
 
-    NT discriminant = b * b - NT(4) * a * c;
+    NT tmin;
+    NT tmax;
 
-    if (discriminant < -tol)
+    if (!solve_ball_line_roots(
+            interior_point, direction, center, radius, tol, tmin, tmax))
     {
-        VT empty(center.rows());
-        empty.setZero();
-
         return std::make_pair(false, empty);
     }
 
-    if (discriminant < NT(0))
-    {
-        discriminant = NT(0);
-    }
-
-    NT sqrt_discriminant = std::sqrt(discriminant);
-
-    NT t1 = (-b - sqrt_discriminant) / (NT(2) * a);
-    NT t2 = (-b + sqrt_discriminant) / (NT(2) * a);
-
-    NT t = t1;
+    NT t = tmin;
 
     if (t < -tol || t > NT(1) + tol)
     {
-        t = t2;
+        t = tmax;
     }
 
     if (t < -tol || t > NT(1) + tol)
     {
-        VT empty(center.rows());
-        empty.setZero();
-
         return std::make_pair(false, empty);
     }
 
     VT candidate = interior_point + t * direction;
 
     return std::make_pair(true, candidate);
+}
+
+/// Computes an approximate Chebyshev center of {x : A x <= b} intersected
+/// with B(center, radius), using cutting-plane linearization of the ball.
+template <typename NT>
+std::pair<bool, Eigen::Matrix<NT, Eigen::Dynamic, 1>>
+chebyshev_center_intersect_ball(
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& A,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& b,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    unsigned int max_iterations = 50,
+    NT tol = NT(1e-8))
+{
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+
+    int m = A.rows();
+    int d = A.cols();
+    int ncols = d + 1;
+
+    std::vector<VT> ball_cuts;
+
+    for (int i = 0; i < d; ++i)
+    {
+        VT positive = VT::Zero(d);
+        positive(i) = NT(1);
+        ball_cuts.push_back(positive);
+
+        VT negative = VT::Zero(d);
+        negative(i) = NT(-1);
+        ball_cuts.push_back(negative);
+    }
+
+    VT solution = center;
+
+    for (unsigned int iteration = 0; iteration < max_iterations; ++iteration)
+    {
+        lprec* lp = make_lp(0, ncols);
+
+        if (lp == NULL)
+        {
+            return std::make_pair(false, solution);
+        }
+
+        REAL infinite = get_infinite(lp);
+
+        for (int j = 0; j < d; ++j)
+        {
+            set_bounds(lp, j + 1, -infinite, infinite);
+        }
+
+        set_bounds(lp, d + 1, 0.0, infinite);
+        set_add_rowmode(lp, TRUE);
+
+        std::vector<int> colno(ncols);
+        std::vector<REAL> row(ncols);
+
+        for (int j = 0; j < ncols; ++j)
+        {
+            colno[j] = j + 1;
+        }
+
+        for (int i = 0; i < m; ++i)
+        {
+            NT normal_norm = A.row(i).norm();
+
+            for (int j = 0; j < d; ++j)
+            {
+                row[j] = A(i, j);
+            }
+
+            row[d] = normal_norm;
+
+            if (!add_constraintex(lp, ncols, row.data(), colno.data(), LE, b(i)))
+            {
+                delete_lp(lp);
+                return std::make_pair(false, solution);
+            }
+        }
+
+        for (VT const& cut : ball_cuts)
+        {
+            for (int j = 0; j < d; ++j)
+            {
+                row[j] = cut(j);
+            }
+
+            row[d] = NT(1);
+
+            NT rhs = radius + cut.dot(center);
+
+            if (!add_constraintex(lp, ncols, row.data(), colno.data(), LE, rhs))
+            {
+                delete_lp(lp);
+                return std::make_pair(false, solution);
+            }
+        }
+
+        set_add_rowmode(lp, FALSE);
+
+        for (int j = 0; j < d; ++j)
+        {
+            row[j] = NT(0);
+        }
+
+        row[d] = NT(1);
+
+        if (!set_obj_fnex(lp, ncols, row.data(), colno.data()))
+        {
+            delete_lp(lp);
+            return std::make_pair(false, solution);
+        }
+
+        set_maxim(lp);
+        set_verbose(lp, NEUTRAL);
+
+        if (solve(lp) != OPTIMAL)
+        {
+            delete_lp(lp);
+            return std::make_pair(false, solution);
+        }
+
+        get_variables(lp, row.data());
+
+        for (int j = 0; j < d; ++j)
+        {
+            solution(j) = row[j];
+        }
+
+        NT inner_radius = row[d];
+
+        delete_lp(lp);
+
+        VT shifted = solution - center;
+        NT distance = shifted.norm();
+
+        if (distance + inner_radius <= radius + tol)
+        {
+            return std::make_pair(true, solution);
+        }
+
+        if (distance <= tol)
+        {
+            return std::make_pair(false, solution);
+        }
+
+        ball_cuts.push_back(shifted / distance);
+    }
+
+    return std::make_pair(false, solution);
 }
 
 /// Returns true if p satisfies A * p <= b.
@@ -328,10 +476,7 @@ find_starting_point_for_component(
 
         VT candidate = intersection.second;
 
-        bool on_sphere =
-            std::abs((candidate - center).norm() - radius) <= NT(100) * tol;
-
-        if (on_sphere && point_satisfies_halfspaces(A, b, candidate, tol))
+        if (point_satisfies_halfspaces(A, b, candidate, tol))
         {
             return std::make_pair(true, candidate);
         }
@@ -397,6 +542,30 @@ find_simplex_ball_components_and_starting_points(
             vertices, components, A, b, interior_point, center, radius, tol);
 
     return std::make_pair(components, starting_points);
+}
+
+/// Finds connected components and starting points, computing an approximate
+/// Chebyshev center of the simplex-ball intersection as the interior point.
+template <typename NT>
+std::pair<
+    std::vector<std::vector<int>>,
+    std::vector<Eigen::Matrix<NT, Eigen::Dynamic, 1>>>
+find_simplex_ball_components_and_starting_points(
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& vertices,
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& A,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& b,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    std::pair<bool, Eigen::Matrix<NT, Eigen::Dynamic, 1>> chebyshev_result =
+        chebyshev_center_intersect_ball(A, b, center, radius, 50, tol);
+
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> interior_point =
+        chebyshev_result.first ? chebyshev_result.second : center;
+
+    return find_simplex_ball_components_and_starting_points(
+        vertices, A, b, interior_point, center, radius, tol);
 }
 
 #endif

--- a/include/convex_bodies/simplexintersectball_components.h
+++ b/include/convex_bodies/simplexintersectball_components.h
@@ -2,11 +2,13 @@
 #define SIMPLEXINTERSECTBALL_COMPONENTS_H
 
 #include <cmath>
-#include <vector>
 #include <queue>
 #include <utility>
+#include <vector>
+
 #include <Eigen/Eigen>
 
+/// Returns true if the segment [u, v] intersects the ball B(center, radius).
 template <typename NT>
 bool segment_intersects_ball(
     Eigen::Matrix<NT, Eigen::Dynamic, 1> const& u,
@@ -50,6 +52,7 @@ bool segment_intersects_ball(
            (t2 >= -tol && t2 <= NT(1) + tol);
 }
 
+/// Returns true if p lies strictly inside the ball B(center, radius).
 template <typename NT>
 bool point_is_inside_ball(
     Eigen::Matrix<NT, Eigen::Dynamic, 1> const& p,
@@ -60,6 +63,34 @@ bool point_is_inside_ball(
     return (p - center).squaredNorm() < radius * radius - tol;
 }
 
+/// Returns a mask for simplex vertices that are outside the ball.
+template <typename NT>
+std::vector<int> active_vertices_outside_ball(
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& vertices,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
+    NT radius = NT(1),
+    NT tol = NT(1e-10))
+{
+    typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+
+    int n = vertices.cols();
+    std::vector<int> active(n, 0);
+
+    for (int i = 0; i < n; ++i)
+    {
+        VT vertex = vertices.col(i);
+
+        if (!point_is_inside_ball(vertex, center, radius, tol))
+        {
+            active[i] = 1;
+        }
+    }
+
+    return active;
+}
+
+/// Builds the graph used to identify connected components of the
+/// simplex-sphere intersection.
 template <typename NT>
 Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> build_simplex_ball_graph(
     Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& vertices,
@@ -72,33 +103,33 @@ Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> build_simplex_ball_graph(
     int n = vertices.cols();
 
     Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> adjacency =
-        Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic>::Ones(n, n);
+        Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic>::Zero(n, n);
+
+    std::vector<int> active =
+        active_vertices_outside_ball(vertices, center, radius, tol);
 
     for (int i = 0; i < n; ++i)
     {
-        adjacency(i, i) = 0;
-    }
-
-    for (int i = 0; i < n; ++i)
-    {
-        VT vi = vertices.col(i);
-
-        if (point_is_inside_ball(vi, center, radius, tol))
+        if (!active[i])
         {
-            adjacency.row(i).setZero();
-            adjacency.col(i).setZero();
             continue;
         }
 
+        VT vi = vertices.col(i);
+
         for (int j = i + 1; j < n; ++j)
         {
+            if (!active[j])
+            {
+                continue;
+            }
+
             VT vj = vertices.col(j);
 
-            if (point_is_inside_ball(vj, center, radius, tol) ||
-                segment_intersects_ball(vi, vj, center, radius, tol))
+            if (!segment_intersects_ball(vi, vj, center, radius, tol))
             {
-                adjacency(i, j) = 0;
-                adjacency(j, i) = 0;
+                adjacency(i, j) = 1;
+                adjacency(j, i) = 1;
             }
         }
     }
@@ -106,8 +137,10 @@ Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> build_simplex_ball_graph(
     return adjacency;
 }
 
+/// Finds connected components of adjacency restricted to active vertices.
 inline std::vector<std::vector<int>> connected_components_from_graph(
-    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> const& adjacency)
+    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> const& adjacency,
+    std::vector<int> const& active)
 {
     int n = adjacency.rows();
 
@@ -116,24 +149,8 @@ inline std::vector<std::vector<int>> connected_components_from_graph(
 
     for (int start = 0; start < n; ++start)
     {
-        if (visited[start])
+        if (visited[start] || !active[start])
         {
-            continue;
-        }
-
-        bool isolated_removed_vertex = true;
-        for (int j = 0; j < n; ++j)
-        {
-            if (adjacency(start, j) != 0 || adjacency(j, start) != 0)
-            {
-                isolated_removed_vertex = false;
-                break;
-            }
-        }
-
-        if (isolated_removed_vertex)
-        {
-            visited[start] = 1;
             continue;
         }
 
@@ -152,7 +169,7 @@ inline std::vector<std::vector<int>> connected_components_from_graph(
 
             for (int next = 0; next < n; ++next)
             {
-                if (!visited[next] && adjacency(current, next) != 0)
+                if (!visited[next] && active[next] && adjacency(current, next) != 0)
                 {
                     visited[next] = 1;
                     queue.push(next);
@@ -160,15 +177,24 @@ inline std::vector<std::vector<int>> connected_components_from_graph(
             }
         }
 
-        if (!component.empty())
-        {
-            components.push_back(component);
-        }
+        components.push_back(component);
     }
 
     return components;
 }
 
+/// Finds connected components of adjacency, treating all vertices as active.
+inline std::vector<std::vector<int>> connected_components_from_graph(
+    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> const& adjacency)
+{
+    int n = adjacency.rows();
+
+    std::vector<int> active(n, 1);
+
+    return connected_components_from_graph(adjacency, active);
+}
+
+/// Finds connected components of the simplex-sphere intersection.
 template <typename NT>
 std::vector<std::vector<int>> find_simplex_ball_components(
     Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& vertices,
@@ -179,11 +205,17 @@ std::vector<std::vector<int>> find_simplex_ball_components(
     Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> adjacency =
         build_simplex_ball_graph(vertices, center, radius, tol);
 
-    return connected_components_from_graph(adjacency);
+    std::vector<int> active =
+        active_vertices_outside_ball(vertices, center, radius, tol);
+
+    return connected_components_from_graph(adjacency, active);
 }
 
+/// Intersects the ray from an interior point to a vertex with the sphere boundary.
 template <typename NT>
-Eigen::Matrix<NT, Eigen::Dynamic, 1> radial_starting_point_from_vertex(
+std::pair<bool, Eigen::Matrix<NT, Eigen::Dynamic, 1>>
+ray_sphere_intersection_from_interior(
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& interior_point,
     Eigen::Matrix<NT, Eigen::Dynamic, 1> const& vertex,
     Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
     NT radius = NT(1),
@@ -191,17 +223,62 @@ Eigen::Matrix<NT, Eigen::Dynamic, 1> radial_starting_point_from_vertex(
 {
     typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
 
-    VT direction = vertex - center;
-    NT norm = direction.norm();
+    VT direction = vertex - interior_point;
+    VT shifted = interior_point - center;
 
-    if (norm <= tol)
+    NT a = direction.dot(direction);
+    NT b = NT(2) * shifted.dot(direction);
+    NT c = shifted.dot(shifted) - radius * radius;
+
+    if (a <= tol)
     {
-        return center;
+        VT empty(center.rows());
+        empty.setZero();
+
+        return std::make_pair(false, empty);
     }
 
-    return center + radius * direction / norm;
+    NT discriminant = b * b - NT(4) * a * c;
+
+    if (discriminant < -tol)
+    {
+        VT empty(center.rows());
+        empty.setZero();
+
+        return std::make_pair(false, empty);
+    }
+
+    if (discriminant < NT(0))
+    {
+        discriminant = NT(0);
+    }
+
+    NT sqrt_discriminant = std::sqrt(discriminant);
+
+    NT t1 = (-b - sqrt_discriminant) / (NT(2) * a);
+    NT t2 = (-b + sqrt_discriminant) / (NT(2) * a);
+
+    NT t = t1;
+
+    if (t < -tol || t > NT(1) + tol)
+    {
+        t = t2;
+    }
+
+    if (t < -tol || t > NT(1) + tol)
+    {
+        VT empty(center.rows());
+        empty.setZero();
+
+        return std::make_pair(false, empty);
+    }
+
+    VT candidate = interior_point + t * direction;
+
+    return std::make_pair(true, candidate);
 }
 
+/// Returns true if p satisfies A * p <= b.
 template <typename NT>
 bool point_satisfies_halfspaces(
     Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& A,
@@ -220,6 +297,8 @@ bool point_satisfies_halfspaces(
     return true;
 }
 
+/// Finds a starting point for one component by intersecting rays from an
+/// interior point to the component vertices with the sphere boundary.
 template <typename NT>
 std::pair<bool, Eigen::Matrix<NT, Eigen::Dynamic, 1>>
 find_starting_point_for_component(
@@ -227,6 +306,7 @@ find_starting_point_for_component(
     std::vector<int> const& component,
     Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& A,
     Eigen::Matrix<NT, Eigen::Dynamic, 1> const& b,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& interior_point,
     Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
     NT radius = NT(1),
     NT tol = NT(1e-10))
@@ -236,7 +316,17 @@ find_starting_point_for_component(
     for (int vertex_index : component)
     {
         VT vertex = vertices.col(vertex_index);
-        VT candidate = radial_starting_point_from_vertex(vertex, center, radius, tol);
+
+        std::pair<bool, VT> intersection =
+            ray_sphere_intersection_from_interior(
+                interior_point, vertex, center, radius, tol);
+
+        if (!intersection.first)
+        {
+            continue;
+        }
+
+        VT candidate = intersection.second;
 
         bool on_sphere =
             std::abs((candidate - center).norm() - radius) <= NT(100) * tol;
@@ -253,6 +343,7 @@ find_starting_point_for_component(
     return std::make_pair(false, empty);
 }
 
+/// Finds one starting point for each connected component.
 template <typename NT>
 std::vector<Eigen::Matrix<NT, Eigen::Dynamic, 1>>
 find_starting_points_for_components(
@@ -260,6 +351,7 @@ find_starting_points_for_components(
     std::vector<std::vector<int>> const& components,
     Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& A,
     Eigen::Matrix<NT, Eigen::Dynamic, 1> const& b,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& interior_point,
     Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
     NT radius = NT(1),
     NT tol = NT(1e-10))
@@ -271,7 +363,8 @@ find_starting_points_for_components(
     for (std::vector<int> const& component : components)
     {
         std::pair<bool, VT> result =
-            find_starting_point_for_component(vertices, component, A, b, center, radius, tol);
+            find_starting_point_for_component(
+                vertices, component, A, b, interior_point, center, radius, tol);
 
         if (result.first)
         {
@@ -282,6 +375,7 @@ find_starting_points_for_components(
     return starting_points;
 }
 
+/// Finds connected components and corresponding starting points.
 template <typename NT>
 std::pair<
     std::vector<std::vector<int>>,
@@ -290,6 +384,7 @@ find_simplex_ball_components_and_starting_points(
     Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& vertices,
     Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> const& A,
     Eigen::Matrix<NT, Eigen::Dynamic, 1> const& b,
+    Eigen::Matrix<NT, Eigen::Dynamic, 1> const& interior_point,
     Eigen::Matrix<NT, Eigen::Dynamic, 1> const& center,
     NT radius = NT(1),
     NT tol = NT(1e-10))
@@ -298,7 +393,8 @@ find_simplex_ball_components_and_starting_points(
         find_simplex_ball_components(vertices, center, radius, tol);
 
     std::vector<Eigen::Matrix<NT, Eigen::Dynamic, 1>> starting_points =
-        find_starting_points_for_components(vertices, components, A, b, center, radius, tol);
+        find_starting_points_for_components(
+            vertices, components, A, b, interior_point, center, radius, tol);
 
     return std::make_pair(components, starting_points);
 }

--- a/include/convex_bodies/simplexintersectball_components.h
+++ b/include/convex_bodies/simplexintersectball_components.h
@@ -2,6 +2,8 @@
 #define SIMPLEXINTERSECTBALL_COMPONENTS_H
 
 #include <cmath>
+#include <vector>
+#include <queue>
 #include <Eigen/Eigen>
 
 template <typename NT>
@@ -101,6 +103,69 @@ Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> build_simplex_ball_graph(
     }
 
     return adjacency;
+}
+
+inline std::vector<std::vector<int>> connected_components_from_graph(
+    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> const& adjacency)
+{
+    int n = adjacency.rows();
+
+    std::vector<int> visited(n, 0);
+    std::vector<std::vector<int>> components;
+
+    for (int start = 0; start < n; ++start)
+    {
+        if (visited[start])
+        {
+            continue;
+        }
+
+        bool isolated_removed_vertex = true;
+        for (int j = 0; j < n; ++j)
+        {
+            if (adjacency(start, j) != 0 || adjacency(j, start) != 0)
+            {
+                isolated_removed_vertex = false;
+                break;
+            }
+        }
+
+        if (isolated_removed_vertex)
+        {
+            visited[start] = 1;
+            continue;
+        }
+
+        std::vector<int> component;
+        std::queue<int> queue;
+
+        visited[start] = 1;
+        queue.push(start);
+
+        while (!queue.empty())
+        {
+            int current = queue.front();
+            queue.pop();
+
+            component.push_back(current);
+
+            for (int next = 0; next < n; ++next)
+            {
+                if (!visited[next] && adjacency(current, next) != 0)
+                {
+                    visited[next] = 1;
+                    queue.push(next);
+                }
+            }
+        }
+
+        if (!component.empty())
+        {
+            components.push_back(component);
+        }
+    }
+
+    return components;
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -436,6 +436,9 @@ add_test(NAME simplexball_components_point_is_inside_ball
           COMMAND simplexintersectball_components_test -tc=simplexball_components_point_is_inside_ball)
 add_test(NAME simplexball_components_build_graph
           COMMAND simplexintersectball_components_test -tc=simplexball_components_build_graph)
+add_test(NAME simplexball_components_connected_components_from_graph
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_connected_components_from_graph)
+          
 set(ADDITIONAL_FLAGS "-march=native -DSIMD_LEN=0 -DTIME_KEEPING")
 
 #set_target_properties(benchmarks_crhmc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -419,6 +419,8 @@ add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection)
 add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection_positive
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection_positive)
+add_test(NAME simplexintersectball_incremental_rotation_matches_fresh
+          COMMAND simplexintersectball_test -tc=simplexintersectball_incremental_rotation_matches_fresh)
 add_test(NAME simplexintersectball_3d_tetrahedron_gc_all_roots
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_all_roots)
 add_test(NAME simplexintersectball_3d_tetrahedron_reflection

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -419,6 +419,8 @@ add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection)
 add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection_positive
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection_positive)
+add_test(NAME simplexintersectball_3d_tetrahedron_gc_all_roots
+          COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_all_roots)
 add_test(NAME simplexintersectball_3d_tetrahedron_reflection
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_reflection)
 add_test(NAME full_dimensional_polytope_orthogonality

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -432,6 +432,8 @@ add_test(NAME full_dimensional_polytope_infeasible
 add_executable (simplexintersectball_components_test simplexintersectball_components_test.cpp $<TARGET_OBJECTS:test_main>)
 add_test(NAME simplexball_components_segment_intersects_ball
           COMMAND simplexintersectball_components_test -tc=simplexball_components_segment_intersects_ball)
+add_test(NAME simplexball_components_point_is_inside_ball
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_point_is_inside_ball)
 set(ADDITIONAL_FLAGS "-march=native -DSIMD_LEN=0 -DTIME_KEEPING")
 
 #set_target_properties(benchmarks_crhmc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -429,9 +429,9 @@ add_test(NAME full_dimensional_polytope_orthogonality
           COMMAND full_dimensional_polytope_test -tc=full_dimensional_polytope_orthogonality)
 add_test(NAME full_dimensional_polytope_infeasible
           COMMAND full_dimensional_polytope_test -tc=full_dimensional_polytope_infeasible)
-
-          
-
+add_executable (simplexintersectball_components_test simplexintersectball_components_test.cpp $<TARGET_OBJECTS:test_main>)
+add_test(NAME simplexball_components_segment_intersects_ball
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_segment_intersects_ball)
 set(ADDITIONAL_FLAGS "-march=native -DSIMD_LEN=0 -DTIME_KEEPING")
 
 #set_target_properties(benchmarks_crhmc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -438,6 +438,9 @@ add_test(NAME simplexball_components_build_graph
           COMMAND simplexintersectball_components_test -tc=simplexball_components_build_graph)
 add_test(NAME simplexball_components_connected_components_from_graph
           COMMAND simplexintersectball_components_test -tc=simplexball_components_connected_components_from_graph)
+add_test(NAME simplexball_components_find_components_from_vertices
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_find_components_from_vertices)
+          
           
 set(ADDITIONAL_FLAGS "-march=native -DSIMD_LEN=0 -DTIME_KEEPING")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -432,29 +432,12 @@ add_test(NAME full_dimensional_polytope_infeasible
 add_executable (simplexintersectball_components_test simplexintersectball_components_test.cpp $<TARGET_OBJECTS:test_main>)
 add_test(NAME simplexball_components_segment_intersects_ball
           COMMAND simplexintersectball_components_test -tc=simplexball_components_segment_intersects_ball)
-add_test(NAME simplexball_components_point_is_inside_ball
-          COMMAND simplexintersectball_components_test -tc=simplexball_components_point_is_inside_ball)
-add_test(NAME simplexball_components_build_graph
-          COMMAND simplexintersectball_components_test -tc=simplexball_components_build_graph)
-add_test(NAME simplexball_components_connected_components_from_graph
-          COMMAND simplexintersectball_components_test -tc=simplexball_components_connected_components_from_graph)
-add_test(NAME simplexball_components_find_components_from_vertices
-          COMMAND simplexintersectball_components_test -tc=simplexball_components_find_components_from_vertices)
-add_test(NAME simplexball_components_radial_starting_point_from_vertex
-          COMMAND simplexintersectball_components_test -tc=simplexball_components_radial_starting_point_from_vertex)       
- add_test(NAME simplexball_components_find_starting_point_for_component
-          COMMAND simplexintersectball_components_test -tc=simplexball_components_find_starting_point_for_component)
-add_test(NAME simplexball_components_find_starting_points_for_components
-          COMMAND simplexintersectball_components_test -tc=simplexball_components_find_starting_points_for_components)
-add_test(NAME simplexball_components_and_starting_points
-          COMMAND simplexintersectball_components_test -tc=simplexball_components_and_starting_points)
-add_test(NAME simplexball_components_finds_two_components
-          COMMAND simplexintersectball_components_test -tc=simplexball_components_finds_two_components)
-
-
-
-
-
+add_test(NAME simplexball_components_tetrahedron_finds_two_components
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_tetrahedron_finds_two_components)
+add_test(NAME simplexball_components_tetrahedron_starting_points
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_tetrahedron_starting_points)
+add_test(NAME simplexball_components_tetrahedron_filters_interior_vertex
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_tetrahedron_filters_interior_vertex)
 set(ADDITIONAL_FLAGS "-march=native -DSIMD_LEN=0 -DTIME_KEEPING")
 
 #set_target_properties(benchmarks_crhmc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -413,6 +413,12 @@ add_test(NAME simplexintersectball_basic_membership
           COMMAND simplexintersectball_test -tc=simplexintersectball_basic_membership)
 add_test(NAME simplexintersectball_line_intersection
           COMMAND simplexintersectball_test -tc=simplexintersectball_line_intersection)
+add_test(NAME simplexintersectball_3d_tetrahedron_membership
+          COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_membership)
+add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection
+          COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection)
+add_test(NAME simplexintersectball_3d_tetrahedron_reflection
+          COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_reflection)
 add_test(NAME full_dimensional_polytope_orthogonality
           COMMAND full_dimensional_polytope_test -tc=full_dimensional_polytope_orthogonality)
 add_test(NAME full_dimensional_polytope_infeasible

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -436,8 +436,13 @@ add_test(NAME simplexball_components_tetrahedron_finds_two_components
           COMMAND simplexintersectball_components_test -tc=simplexball_components_tetrahedron_finds_two_components)
 add_test(NAME simplexball_components_tetrahedron_starting_points
           COMMAND simplexintersectball_components_test -tc=simplexball_components_tetrahedron_starting_points)
+add_test(NAME simplexball_components_tetrahedron_starting_points_with_chebyshev_center
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_tetrahedron_starting_points_with_chebyshev_center)
 add_test(NAME simplexball_components_tetrahedron_filters_interior_vertex
           COMMAND simplexintersectball_components_test -tc=simplexball_components_tetrahedron_filters_interior_vertex)
+add_test(NAME simplexball_components_chebyshev_center_intersect_ball
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_chebyshev_center_intersect_ball)
+TARGET_LINK_LIBRARIES(simplexintersectball_components_test lp_solve coverage_config)
 set(ADDITIONAL_FLAGS "-march=native -DSIMD_LEN=0 -DTIME_KEEPING")
 
 #set_target_properties(benchmarks_crhmc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -446,7 +446,8 @@ add_test(NAME simplexball_components_radial_starting_point_from_vertex
           COMMAND simplexintersectball_components_test -tc=simplexball_components_find_starting_point_for_component)
 add_test(NAME simplexball_components_find_starting_points_for_components
           COMMAND simplexintersectball_components_test -tc=simplexball_components_find_starting_points_for_components)
-
+add_test(NAME simplexball_components_and_starting_points
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_and_starting_points)
 
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -417,6 +417,8 @@ add_test(NAME simplexintersectball_3d_tetrahedron_membership
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_membership)
 add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection)
+add_test(NAME simplexintersectball_3d_tetrahedron_gc_intersection_positive
+          COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_gc_intersection_positive)
 add_test(NAME simplexintersectball_3d_tetrahedron_reflection
           COMMAND simplexintersectball_test -tc=simplexintersectball_3d_tetrahedron_reflection)
 add_test(NAME full_dimensional_polytope_orthogonality

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -434,6 +434,8 @@ add_test(NAME simplexball_components_segment_intersects_ball
           COMMAND simplexintersectball_components_test -tc=simplexball_components_segment_intersects_ball)
 add_test(NAME simplexball_components_point_is_inside_ball
           COMMAND simplexintersectball_components_test -tc=simplexball_components_point_is_inside_ball)
+add_test(NAME simplexball_components_build_graph
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_build_graph)
 set(ADDITIONAL_FLAGS "-march=native -DSIMD_LEN=0 -DTIME_KEEPING")
 
 #set_target_properties(benchmarks_crhmc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -442,9 +442,10 @@ add_test(NAME simplexball_components_find_components_from_vertices
           COMMAND simplexintersectball_components_test -tc=simplexball_components_find_components_from_vertices)
 add_test(NAME simplexball_components_radial_starting_point_from_vertex
           COMMAND simplexintersectball_components_test -tc=simplexball_components_radial_starting_point_from_vertex)       
- 
-          
-
+ add_test(NAME simplexball_components_find_starting_point_for_component
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_find_starting_point_for_component)
+add_test(NAME simplexball_components_find_starting_points_for_components
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_find_starting_points_for_components)
 
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -440,8 +440,18 @@ add_test(NAME simplexball_components_connected_components_from_graph
           COMMAND simplexintersectball_components_test -tc=simplexball_components_connected_components_from_graph)
 add_test(NAME simplexball_components_find_components_from_vertices
           COMMAND simplexintersectball_components_test -tc=simplexball_components_find_components_from_vertices)
+add_test(NAME simplexball_components_radial_starting_point_from_vertex
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_radial_starting_point_from_vertex)       
+ 
           
-          
+
+
+
+
+
+
+
+
 set(ADDITIONAL_FLAGS "-march=native -DSIMD_LEN=0 -DTIME_KEEPING")
 
 #set_target_properties(benchmarks_crhmc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -448,7 +448,8 @@ add_test(NAME simplexball_components_find_starting_points_for_components
           COMMAND simplexintersectball_components_test -tc=simplexball_components_find_starting_points_for_components)
 add_test(NAME simplexball_components_and_starting_points
           COMMAND simplexintersectball_components_test -tc=simplexball_components_and_starting_points)
-
+add_test(NAME simplexball_components_finds_two_components
+          COMMAND simplexintersectball_components_test -tc=simplexball_components_finds_two_components)
 
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -408,6 +408,11 @@ add_test(NAME full_dimensional_polytope_hypercube_intersection
           COMMAND full_dimensional_polytope_test -tc=full_dimensional_polytope_hypercube_intersection)
 add_test(NAME full_dimensional_polytope_sparse_constraint
           COMMAND full_dimensional_polytope_test -tc=full_dimensional_polytope_sparse_constraint)
+add_executable (simplexintersectball_test simplexintersectball_test.cpp $<TARGET_OBJECTS:test_main>)
+add_test(NAME simplexintersectball_basic_membership
+          COMMAND simplexintersectball_test -tc=simplexintersectball_basic_membership)
+add_test(NAME simplexintersectball_line_intersection
+          COMMAND simplexintersectball_test -tc=simplexintersectball_line_intersection)
 add_test(NAME full_dimensional_polytope_orthogonality
           COMMAND full_dimensional_polytope_test -tc=full_dimensional_polytope_orthogonality)
 add_test(NAME full_dimensional_polytope_infeasible

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -52,3 +52,39 @@ TEST_CASE("simplexball_components_point_is_inside_ball")
     p << 1.5, 0.0;
     CHECK_FALSE(point_is_inside_ball(p, center, NT(1)));
 }
+
+TEST_CASE("simplexball_components_build_graph")
+{
+    VT center(2);
+    center << 0, 0;
+
+    // 4 vertices around the unit ball.
+    // Edges through the ball should be removed.
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 4);
+    vertices << -2,  2,  0,  0,
+                 0,  0,  2, -2;
+
+    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> graph =
+        build_simplex_ball_graph(vertices, center, NT(1));
+
+    CHECK(graph.rows() == 4);
+    CHECK(graph.cols() == 4);
+
+    // No self-loops.
+    CHECK(graph(0, 0) == 0);
+    CHECK(graph(1, 1) == 0);
+    CHECK(graph(2, 2) == 0);
+    CHECK(graph(3, 3) == 0);
+
+    // Segment from (-2,0) to (2,0) crosses the ball.
+    CHECK(graph(0, 1) == 0);
+    CHECK(graph(1, 0) == 0);
+
+    // Segment from (0,2) to (0,-2) crosses the ball.
+    CHECK(graph(2, 3) == 0);
+    CHECK(graph(3, 2) == 0);
+
+    // Segment from (-2,0) to (0,2) is tangent/outside boundary-connected.
+    CHECK(graph(0, 2) == 1);
+    CHECK(graph(2, 0) == 1);
+}

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -234,3 +234,38 @@ TEST_CASE("simplexball_components_find_starting_points_for_components")
     CHECK(p.norm() == doctest::Approx(1.0));
     CHECK(point_satisfies_halfspaces(A, b, p));
 }
+
+TEST_CASE("simplexball_components_and_starting_points")
+{
+    VT center(2);
+    center << 0, 0;
+
+    // Triangle:
+    // x >= 0, y >= 0, x + y <= 2
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> A(3, 2);
+    A << -1,  0,
+          0, -1,
+          1,  1;
+
+    VT b(3);
+    b << 0, 0, 2;
+
+    // Vertices stored column-wise: (0,0), (2,0), (0,2)
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 3);
+    vertices << 0, 2, 0,
+                0, 0, 2;
+
+    std::pair<std::vector<std::vector<int>>, std::vector<VT>> result =
+        find_simplex_ball_components_and_starting_points(vertices, A, b, center, NT(1));
+
+    std::vector<std::vector<int>> components = result.first;
+    std::vector<VT> starting_points = result.second;
+
+    CHECK(components.size() == 1);
+    CHECK(starting_points.size() == 1);
+
+    VT p = starting_points[0];
+
+    CHECK(p.norm() == doctest::Approx(1.0));
+    CHECK(point_satisfies_halfspaces(A, b, p));
+}

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -35,3 +35,20 @@ TEST_CASE("simplexball_components_segment_intersects_ball")
     v << 2, 0;
     CHECK(segment_intersects_ball(u, v, center, NT(1)));
 }
+
+TEST_CASE("simplexball_components_point_is_inside_ball")
+{
+    VT center(2);
+    center << 0, 0;
+
+    VT p(2);
+
+    p << 0.5, 0.0;
+    CHECK(point_is_inside_ball(p, center, NT(1)));
+
+    p << 1.0, 0.0;
+    CHECK_FALSE(point_is_inside_ball(p, center, NT(1)));
+
+    p << 1.5, 0.0;
+    CHECK_FALSE(point_is_inside_ball(p, center, NT(1)));
+}

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -9,284 +9,117 @@ typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
 
 TEST_CASE("simplexball_components_segment_intersects_ball")
 {
-    VT center(2);
-    center << 0, 0;
+    VT center(3);
+    center << 0, 0, 0;
 
-    VT u(2);
-    VT v(2);
+    VT u(3);
+    VT v(3);
 
     // Segment crosses the unit ball.
-    u << -2, 0;
-    v << 2, 0;
+    u << -2, 0, 0;
+    v << 2, 0, 0;
     CHECK(segment_intersects_ball(u, v, center, NT(1)));
 
     // Segment stays outside the unit ball.
-    u << 2, 2;
-    v << 3, 2;
+    u << 2, 2, 0;
+    v << 3, 2, 0;
     CHECK_FALSE(segment_intersects_ball(u, v, center, NT(1)));
 
     // Segment is tangent to the unit ball.
-    u << -1, 1;
-    v << 1, 1;
-    CHECK(segment_intersects_ball(u, v, center, NT(1)));
-
-    // Segment starts inside the unit ball.
-    u << 0, 0;
-    v << 2, 0;
+    u << -1, 1, 0;
+    v << 1, 1, 0;
     CHECK(segment_intersects_ball(u, v, center, NT(1)));
 }
 
-TEST_CASE("simplexball_components_point_is_inside_ball")
+TEST_CASE("simplexball_components_tetrahedron_finds_two_components")
 {
-    VT center(2);
-    center << 0, 0;
+    VT center(3);
+    center << 0, 0, 0;
 
-    VT p(2);
-
-    p << 0.5, 0.0;
-    CHECK(point_is_inside_ball(p, center, NT(1)));
-
-    p << 1.0, 0.0;
-    CHECK_FALSE(point_is_inside_ball(p, center, NT(1)));
-
-    p << 1.5, 0.0;
-    CHECK_FALSE(point_is_inside_ball(p, center, NT(1)));
-}
-
-TEST_CASE("simplexball_components_build_graph")
-{
-    VT center(2);
-    center << 0, 0;
-
-    // 4 vertices around the unit ball.
-    // Edges through the ball should be removed.
-    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 4);
-    vertices << -2,  2,  0,  0,
-                 0,  0,  2, -2;
-
-    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> graph =
-        build_simplex_ball_graph(vertices, center, NT(1));
-
-    CHECK(graph.rows() == 4);
-    CHECK(graph.cols() == 4);
-
-    // No self-loops.
-    CHECK(graph(0, 0) == 0);
-    CHECK(graph(1, 1) == 0);
-    CHECK(graph(2, 2) == 0);
-    CHECK(graph(3, 3) == 0);
-
-    // Segment from (-2,0) to (2,0) crosses the ball.
-    CHECK(graph(0, 1) == 0);
-    CHECK(graph(1, 0) == 0);
-
-    // Segment from (0,2) to (0,-2) crosses the ball.
-    CHECK(graph(2, 3) == 0);
-    CHECK(graph(3, 2) == 0);
-
-    // Segment from (-2,0) to (0,2) is tangent/outside boundary-connected.
-    CHECK(graph(0, 2) == 1);
-    CHECK(graph(2, 0) == 1);
-}
-
-TEST_CASE("simplexball_components_connected_components_from_graph")
-{
-    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> graph(5, 5);
-    graph.setZero();
-
-    // Component 1: 0 -- 1
-    graph(0, 1) = 1;
-    graph(1, 0) = 1;
-
-    // Component 2: 2 -- 3
-    graph(2, 3) = 1;
-    graph(3, 2) = 1;
-
-    // Vertex 4 is isolated and should be ignored.
+    // Non-degenerate tetrahedron in R^3.
+    // Vertices 0 and 1 form one component.
+    // Vertices 2 and 3 form the other component.
+    // Every edge between the two pairs intersects the unit ball.
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(3, 4);
+    vertices << -2, -2,  2,  2,
+                -0.2, 0.2, -0.2, 0.2,
+                -0.2, 0.2,  0.2, -0.2;
 
     std::vector<std::vector<int>> components =
-        connected_components_from_graph(graph);
+        find_simplex_ball_components(vertices, center, NT(1));
 
-    CHECK(components.size() == 2);
+    REQUIRE(components.size() == 2);
 
     CHECK(components[0].size() == 2);
-    CHECK(components[1].size() == 2);
-
     CHECK(components[0][0] == 0);
     CHECK(components[0][1] == 1);
 
+    CHECK(components[1].size() == 2);
     CHECK(components[1][0] == 2);
     CHECK(components[1][1] == 3);
 }
 
-TEST_CASE("simplexball_components_find_components_from_vertices")
+TEST_CASE("simplexball_components_tetrahedron_starting_points")
 {
-    VT center(2);
-    center << 0, 0;
+    VT center(3);
+    center << 0, 0, 0;
 
-    // Same 4 vertices as before:
-    // left, right, top, bottom around the unit ball.
-    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 4);
-    vertices << -2,  2,  0,  0,
-                 0,  0,  2, -2;
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(3, 4);
+    vertices << -2, -2,  2,  2,
+                -0.2, 0.2, -0.2, 0.2,
+                -0.2, 0.2,  0.2, -0.2;
 
-    std::vector<std::vector<int>> components =
-        find_simplex_ball_components(vertices, center, NT(1));
+    // H-representation of the tetrahedron above.
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> A(4, 3);
+    A <<  1,  10,  10,
+          1, -10, -10,
+         -1,  10, -10,
+         -1, -10,  10;
 
-    CHECK(components.size() == 1);
+    VT b(4);
+    b << 2, 2, 2, 2;
 
-    CHECK(components[0].size() == 4);
-    CHECK(components[0][0] == 0);
-    CHECK(components[0][1] == 2);
-    CHECK(components[0][2] == 3);
-    CHECK(components[0][3] == 1);
-}
-
-TEST_CASE("simplexball_components_radial_starting_point_from_vertex")
-{
-    VT center(2);
-    center << 0, 0;
-
-    VT vertex(2);
-    vertex << 2, 0;
-
-    VT p = radial_starting_point_from_vertex(vertex, center, NT(1));
-
-    CHECK(p.rows() == 2);
-    CHECK(p(0) == doctest::Approx(1.0));
-    CHECK(p(1) == doctest::Approx(0.0));
-    CHECK(p.norm() == doctest::Approx(1.0));
-
-    vertex << 0, -3;
-
-    p = radial_starting_point_from_vertex(vertex, center, NT(1));
-
-    CHECK(p(0) == doctest::Approx(0.0));
-    CHECK(p(1) == doctest::Approx(-1.0));
-    CHECK(p.norm() == doctest::Approx(1.0));
-}
-
-TEST_CASE("simplexball_components_find_starting_point_for_component")
-{
-    VT center(2);
-    center << 0, 0;
-
-    // Triangle:
-    // x >= 0, y >= 0, x + y <= 2
-    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> A(3, 2);
-    A << -1,  0,
-          0, -1,
-          1,  1;
-
-    VT b(3);
-    b << 0, 0, 2;
-
-    // Vertices stored column-wise: (0,0), (2,0), (0,2)
-    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 3);
-    vertices << 0, 2, 0,
-                0, 0, 2;
-
-    std::vector<int> component;
-    component.push_back(1); // vertex (2,0)
-    component.push_back(2); // vertex (0,2)
-
-    std::pair<bool, VT> result =
-        find_starting_point_for_component(vertices, component, A, b, center, NT(1));
-
-    CHECK(result.first);
-
-    VT p = result.second;
-
-    CHECK(p.norm() == doctest::Approx(1.0));
-    CHECK(point_satisfies_halfspaces(A, b, p));
-}
-
-TEST_CASE("simplexball_components_find_starting_points_for_components")
-{
-    VT center(2);
-    center << 0, 0;
-
-    // Triangle:
-    // x >= 0, y >= 0, x + y <= 2
-    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> A(3, 2);
-    A << -1,  0,
-          0, -1,
-          1,  1;
-
-    VT b(3);
-    b << 0, 0, 2;
-
-    // Vertices stored column-wise: (0,0), (2,0), (0,2)
-    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 3);
-    vertices << 0, 2, 0,
-                0, 0, 2;
-
-    std::vector<std::vector<int>> components;
-    components.push_back({1, 2});
-
-    std::vector<VT> starting_points =
-        find_starting_points_for_components(vertices, components, A, b, center, NT(1));
-
-    CHECK(starting_points.size() == 1);
-
-    VT p = starting_points[0];
-
-    CHECK(p.norm() == doctest::Approx(1.0));
-    CHECK(point_satisfies_halfspaces(A, b, p));
-}
-
-TEST_CASE("simplexball_components_and_starting_points")
-{
-    VT center(2);
-    center << 0, 0;
-
-    // Triangle:
-    // x >= 0, y >= 0, x + y <= 2
-    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> A(3, 2);
-    A << -1,  0,
-          0, -1,
-          1,  1;
-
-    VT b(3);
-    b << 0, 0, 2;
-
-    // Vertices stored column-wise: (0,0), (2,0), (0,2)
-    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 3);
-    vertices << 0, 2, 0,
-                0, 0, 2;
+    VT interior_point(3);
+    interior_point << 0, 0, 0;
 
     std::pair<std::vector<std::vector<int>>, std::vector<VT>> result =
-        find_simplex_ball_components_and_starting_points(vertices, A, b, center, NT(1));
+        find_simplex_ball_components_and_starting_points(
+            vertices, A, b, interior_point, center, NT(1));
 
-    std::vector<std::vector<int>> components = result.first;
-    std::vector<VT> starting_points = result.second;
+    REQUIRE(result.first.size() == 2);
+    REQUIRE(result.second.size() == 2);
 
-    CHECK(components.size() == 1);
-    CHECK(starting_points.size() == 1);
-
-    VT p = starting_points[0];
-
-    CHECK(p.norm() == doctest::Approx(1.0));
-    CHECK(point_satisfies_halfspaces(A, b, p));
+    for (VT const& p : result.second)
+    {
+        CHECK(p.rows() == 3);
+        CHECK(p.norm() == doctest::Approx(1.0));
+        CHECK(point_satisfies_halfspaces(A, b, p));
+    }
 }
 
-TEST_CASE("simplexball_components_finds_two_components")
+TEST_CASE("simplexball_components_tetrahedron_filters_interior_vertex")
 {
-    VT center(2);
-    center << 0, 0;
+    VT center(3);
+    center << 0, 0, 0;
 
-    // Two clusters on opposite sides of the unit ball.
-    // Within each cluster, the segment stays outside the ball.
-    // Between clusters, every segment crosses the ball.
-    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 4);
-    vertices << -2, -2,  2,  2,
-                -0.2, 0.2, -0.2, 0.2;
+    // Non-degenerate tetrahedron with one vertex inside the unit ball.
+    // Vertex 3 is inside and should be ignored.
+    // Vertex 0 remains an isolated active component.
+    // Vertices 1 and 2 remain connected.
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(3, 4);
+    vertices << -2,  2,  2,  0,
+                 0,  0,  0.5, 0.1,
+                 0,  0,  0.5, 0;
 
     std::vector<std::vector<int>> components =
         find_simplex_ball_components(vertices, center, NT(1));
 
-    CHECK(components.size() == 2);
+    REQUIRE(components.size() == 2);
 
-    CHECK(components[0].size() == 2);
+    CHECK(components[0].size() == 1);
+    CHECK(components[0][0] == 0);
+
     CHECK(components[1].size() == 2);
+    CHECK(components[1][0] == 1);
+    CHECK(components[1][1] == 2);
 }

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -165,3 +165,72 @@ TEST_CASE("simplexball_components_radial_starting_point_from_vertex")
     CHECK(p(1) == doctest::Approx(-1.0));
     CHECK(p.norm() == doctest::Approx(1.0));
 }
+
+TEST_CASE("simplexball_components_find_starting_point_for_component")
+{
+    VT center(2);
+    center << 0, 0;
+
+    // Triangle:
+    // x >= 0, y >= 0, x + y <= 2
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> A(3, 2);
+    A << -1,  0,
+          0, -1,
+          1,  1;
+
+    VT b(3);
+    b << 0, 0, 2;
+
+    // Vertices stored column-wise: (0,0), (2,0), (0,2)
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 3);
+    vertices << 0, 2, 0,
+                0, 0, 2;
+
+    std::vector<int> component;
+    component.push_back(1); // vertex (2,0)
+    component.push_back(2); // vertex (0,2)
+
+    std::pair<bool, VT> result =
+        find_starting_point_for_component(vertices, component, A, b, center, NT(1));
+
+    CHECK(result.first);
+
+    VT p = result.second;
+
+    CHECK(p.norm() == doctest::Approx(1.0));
+    CHECK(point_satisfies_halfspaces(A, b, p));
+}
+
+TEST_CASE("simplexball_components_find_starting_points_for_components")
+{
+    VT center(2);
+    center << 0, 0;
+
+    // Triangle:
+    // x >= 0, y >= 0, x + y <= 2
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> A(3, 2);
+    A << -1,  0,
+          0, -1,
+          1,  1;
+
+    VT b(3);
+    b << 0, 0, 2;
+
+    // Vertices stored column-wise: (0,0), (2,0), (0,2)
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 3);
+    vertices << 0, 2, 0,
+                0, 0, 2;
+
+    std::vector<std::vector<int>> components;
+    components.push_back({1, 2});
+
+    std::vector<VT> starting_points =
+        find_starting_points_for_components(vertices, components, A, b, center, NT(1));
+
+    CHECK(starting_points.size() == 1);
+
+    VT p = starting_points[0];
+
+    CHECK(p.norm() == doctest::Approx(1.0));
+    CHECK(point_satisfies_halfspaces(A, b, p));
+}

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -31,6 +31,35 @@ TEST_CASE("simplexball_components_segment_intersects_ball")
     CHECK(segment_intersects_ball(u, v, center, NT(1)));
 }
 
+TEST_CASE("simplexball_components_chebyshev_center_intersect_ball")
+{
+    VT center(2);
+    center << 0, 0;
+
+    // Feasible set: {x <= 0.4} intersected with the unit ball.
+    // The largest inscribed ball is centered at (-0.3, 0) with radius 0.7.
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> A(4, 2);
+    A <<  1,  0,
+         -1,  0,
+          0,  1,
+          0, -1;
+
+    VT b(4);
+    b << 0.4, 2.0, 2.0, 2.0;
+
+    std::pair<bool, VT> result =
+        chebyshev_center_intersect_ball(A, b, center, NT(1), 100, NT(1e-10));
+
+    REQUIRE(result.first);
+
+    VT xc = result.second;
+
+    CHECK(xc(0) == doctest::Approx(-0.3).epsilon(1e-5));
+    CHECK(xc(1) == doctest::Approx(0.0).epsilon(1e-5));
+    CHECK((A * xc - b).maxCoeff() <= doctest::Approx(0.0).epsilon(1e-8));
+    CHECK((xc - center).norm() < 1.0);
+}
+
 TEST_CASE("simplexball_components_tetrahedron_finds_two_components")
 {
     VT center(3);
@@ -85,6 +114,41 @@ TEST_CASE("simplexball_components_tetrahedron_starting_points")
     std::pair<std::vector<std::vector<int>>, std::vector<VT>> result =
         find_simplex_ball_components_and_starting_points(
             vertices, A, b, interior_point, center, NT(1));
+
+    REQUIRE(result.first.size() == 2);
+    REQUIRE(result.second.size() == 2);
+
+    for (VT const& p : result.second)
+    {
+        CHECK(p.rows() == 3);
+        CHECK(p.norm() == doctest::Approx(1.0));
+        CHECK(point_satisfies_halfspaces(A, b, p));
+    }
+}
+
+TEST_CASE("simplexball_components_tetrahedron_starting_points_with_chebyshev_center")
+{
+    VT center(3);
+    center << 0, 0, 0;
+
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(3, 4);
+    vertices << -2, -2,  2,  2,
+                -0.2, 0.2, -0.2, 0.2,
+                -0.2, 0.2,  0.2, -0.2;
+
+    // H-representation of the tetrahedron above.
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> A(4, 3);
+    A <<  1,  10,  10,
+          1, -10, -10,
+         -1,  10, -10,
+         -1, -10,  10;
+
+    VT b(4);
+    b << 2, 2, 2, 2;
+
+    std::pair<std::vector<std::vector<int>>, std::vector<VT>> result =
+        find_simplex_ball_components_and_starting_points(
+            vertices, A, b, center, NT(1));
 
     REQUIRE(result.first.size() == 2);
     REQUIRE(result.second.size() == 2);

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -269,3 +269,24 @@ TEST_CASE("simplexball_components_and_starting_points")
     CHECK(p.norm() == doctest::Approx(1.0));
     CHECK(point_satisfies_halfspaces(A, b, p));
 }
+
+TEST_CASE("simplexball_components_finds_two_components")
+{
+    VT center(2);
+    center << 0, 0;
+
+    // Two clusters on opposite sides of the unit ball.
+    // Within each cluster, the segment stays outside the ball.
+    // Between clusters, every segment crosses the ball.
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 4);
+    vertices << -2, -2,  2,  2,
+                -0.2, 0.2, -0.2, 0.2;
+
+    std::vector<std::vector<int>> components =
+        find_simplex_ball_components(vertices, center, NT(1));
+
+    CHECK(components.size() == 2);
+
+    CHECK(components[0].size() == 2);
+    CHECK(components[1].size() == 2);
+}

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -118,3 +118,26 @@ TEST_CASE("simplexball_components_connected_components_from_graph")
     CHECK(components[1][0] == 2);
     CHECK(components[1][1] == 3);
 }
+
+TEST_CASE("simplexball_components_find_components_from_vertices")
+{
+    VT center(2);
+    center << 0, 0;
+
+    // Same 4 vertices as before:
+    // left, right, top, bottom around the unit ball.
+    Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> vertices(2, 4);
+    vertices << -2,  2,  0,  0,
+                 0,  0,  2, -2;
+
+    std::vector<std::vector<int>> components =
+        find_simplex_ball_components(vertices, center, NT(1));
+
+    CHECK(components.size() == 1);
+
+    CHECK(components[0].size() == 4);
+    CHECK(components[0][0] == 0);
+    CHECK(components[0][1] == 2);
+    CHECK(components[0][2] == 3);
+    CHECK(components[0][3] == 1);
+}

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -141,3 +141,27 @@ TEST_CASE("simplexball_components_find_components_from_vertices")
     CHECK(components[0][2] == 3);
     CHECK(components[0][3] == 1);
 }
+
+TEST_CASE("simplexball_components_radial_starting_point_from_vertex")
+{
+    VT center(2);
+    center << 0, 0;
+
+    VT vertex(2);
+    vertex << 2, 0;
+
+    VT p = radial_starting_point_from_vertex(vertex, center, NT(1));
+
+    CHECK(p.rows() == 2);
+    CHECK(p(0) == doctest::Approx(1.0));
+    CHECK(p(1) == doctest::Approx(0.0));
+    CHECK(p.norm() == doctest::Approx(1.0));
+
+    vertex << 0, -3;
+
+    p = radial_starting_point_from_vertex(vertex, center, NT(1));
+
+    CHECK(p(0) == doctest::Approx(0.0));
+    CHECK(p(1) == doctest::Approx(-1.0));
+    CHECK(p.norm() == doctest::Approx(1.0));
+}

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -88,3 +88,33 @@ TEST_CASE("simplexball_components_build_graph")
     CHECK(graph(0, 2) == 1);
     CHECK(graph(2, 0) == 1);
 }
+
+TEST_CASE("simplexball_components_connected_components_from_graph")
+{
+    Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic> graph(5, 5);
+    graph.setZero();
+
+    // Component 1: 0 -- 1
+    graph(0, 1) = 1;
+    graph(1, 0) = 1;
+
+    // Component 2: 2 -- 3
+    graph(2, 3) = 1;
+    graph(3, 2) = 1;
+
+    // Vertex 4 is isolated and should be ignored.
+
+    std::vector<std::vector<int>> components =
+        connected_components_from_graph(graph);
+
+    CHECK(components.size() == 2);
+
+    CHECK(components[0].size() == 2);
+    CHECK(components[1].size() == 2);
+
+    CHECK(components[0][0] == 0);
+    CHECK(components[0][1] == 1);
+
+    CHECK(components[1][0] == 2);
+    CHECK(components[1][1] == 3);
+}

--- a/test/simplexintersectball_components_test.cpp
+++ b/test/simplexintersectball_components_test.cpp
@@ -1,0 +1,37 @@
+#include "doctest.h"
+
+#include <Eigen/Eigen>
+
+#include "convex_bodies/simplexintersectball_components.h"
+
+typedef double NT;
+typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+
+TEST_CASE("simplexball_components_segment_intersects_ball")
+{
+    VT center(2);
+    center << 0, 0;
+
+    VT u(2);
+    VT v(2);
+
+    // Segment crosses the unit ball.
+    u << -2, 0;
+    v << 2, 0;
+    CHECK(segment_intersects_ball(u, v, center, NT(1)));
+
+    // Segment stays outside the unit ball.
+    u << 2, 2;
+    v << 3, 2;
+    CHECK_FALSE(segment_intersects_ball(u, v, center, NT(1)));
+
+    // Segment is tangent to the unit ball.
+    u << -1, 1;
+    v << 1, 1;
+    CHECK(segment_intersects_ball(u, v, center, NT(1)));
+
+    // Segment starts inside the unit ball.
+    u << 0, 0;
+    v << 2, 0;
+    CHECK(segment_intersects_ball(u, v, center, NT(1)));
+}

--- a/test/simplexintersectball_test.cpp
+++ b/test/simplexintersectball_test.cpp
@@ -19,10 +19,10 @@ SimplexBall make_3d_tetrahedron_unit_ball()
     // Tetrahedron in R^3:
     // x >= 0, y >= 0, z >= 0, x + y + z <= 2
     MT A(4, 3);
-    A << -1,  0,  0,
-          0, -1,  0,
-          0,  0, -1,
-          1,  1,  1;
+    A << -1, 0, 0,
+        0, -1, 0,
+        0, 0, -1,
+        1, 1, 1;
 
     VT b(4);
     b << 0, 0, 0, 2;
@@ -31,8 +31,8 @@ SimplexBall make_3d_tetrahedron_unit_ball()
     // (0,0,0), (2,0,0), (0,2,0), (0,0,2)
     MT V(3, 4);
     V << 0, 2, 0, 0,
-         0, 0, 2, 0,
-         0, 0, 0, 2;
+        0, 0, 2, 0,
+        0, 0, 0, 2;
 
     VT x0(3);
     x0 << 0, 0, 0;
@@ -47,9 +47,9 @@ TEST_CASE("simplexintersectball_basic_membership")
     // Simplex in R^2:
     // x >= 0, y >= 0, x + y <= 1
     MT A(3, 2);
-    A << -1,  0,
-          0, -1,
-          1,  1;
+    A << -1, 0,
+        0, -1,
+        1, 1;
 
     VT b(3);
     b << 0, 0, 1;
@@ -57,7 +57,7 @@ TEST_CASE("simplexintersectball_basic_membership")
     // Vertices stored column-wise: (0,0), (1,0), (0,1)
     MT V(2, 3);
     V << 0, 1, 0,
-         0, 0, 1;
+        0, 0, 1;
 
     VT x0(2);
     x0 << 0, 0;
@@ -89,16 +89,16 @@ TEST_CASE("simplexintersectball_line_intersection")
     unsigned int d = 2;
 
     MT A(3, 2);
-    A << -1,  0,
-          0, -1,
-          1,  1;
+    A << -1, 0,
+        0, -1,
+        1, 1;
 
     VT b(3);
     b << 0, 0, 1;
 
     MT V(2, 3);
     V << 0, 1, 0,
-         0, 0, 1;
+        0, 0, 1;
 
     VT x0(2);
     x0 << 0, 0;
@@ -195,12 +195,39 @@ TEST_CASE("simplexintersectball_3d_tetrahedron_gc_intersection_positive")
     CHECK(hit.second == 1);
 }
 
+TEST_CASE("simplexintersectball_incremental_rotation_matches_fresh")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    NT inv_sqrt3 = NT(1) / std::sqrt(NT(3));
+    NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
+
+    VT r0(3);
+    r0 << inv_sqrt3, inv_sqrt3, inv_sqrt3;
+    VT v0(3);
+    v0 << inv_sqrt2, -inv_sqrt2, 0;
+    Point pr0(r0), pv0(v0);
+
+    VT Ar, Av;
+    K.gc_intersect(pr0, pv0, Ar, Av);
+
+    NT lambda = 0.3;
+    std::pair<NT, NT> inc = K.gc_intersect(pr0, pv0, Ar, Av, lambda);
+
+    VT r1 = std::cos(lambda) * r0 + std::sin(lambda) * v0;
+    Point pr1(r1);
+    VT Ar2, Av2;
+    std::pair<NT, NT> fresh = K.gc_intersect(pr1, pv0, Ar2, Av2);
+
+    CHECK(inc.first == doctest::Approx(fresh.first));
+    CHECK(inc.second == doctest::Approx(fresh.second));
+}
+
 TEST_CASE("simplexintersectball_3d_tetrahedron_reflection")
 {
     SimplexBall K = make_3d_tetrahedron_unit_ball();
 
     NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
-
     // Point on the unit sphere and on the facet y = 0
     VT p(3);
     p << inv_sqrt2, 0, inv_sqrt2;

--- a/test/simplexintersectball_test.cpp
+++ b/test/simplexintersectball_test.cpp
@@ -219,3 +219,50 @@ TEST_CASE("simplexintersectball_3d_tetrahedron_reflection")
     CHECK(v(1) == doctest::Approx(1.0));
     CHECK(v(2) == doctest::Approx(0.0));
 }
+
+TEST_CASE("simplexintersectball_3d_tetrahedron_gc_all_roots")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    NT inv_sqrt3 = NT(1) / std::sqrt(NT(3));
+    NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
+
+    VT r_vec(3);
+    r_vec << inv_sqrt3, inv_sqrt3, inv_sqrt3;
+    Point r(r_vec);
+
+    VT v_vec(3);
+    v_vec << inv_sqrt2, -inv_sqrt2, 0;
+    Point v(v_vec);
+
+    VT Ar;
+    VT Av;
+
+    std::pair<VT, VT> roots = K.gc_intersect_all_roots(r, v, Ar, Av);
+
+    NT alpha = std::atan(std::sqrt(NT(2) / NT(3)));
+
+    CHECK(roots.first.rows() >= 1);
+    CHECK(roots.second.rows() >= 1);
+
+    bool found_negative_alpha = false;
+    for (int i = 0; i < roots.first.rows(); ++i)
+    {
+        if (std::abs(roots.first(i) + alpha) < NT(1e-08))
+        {
+            found_negative_alpha = true;
+        }
+    }
+
+    bool found_positive_alpha = false;
+    for (int i = 0; i < roots.second.rows(); ++i)
+    {
+        if (std::abs(roots.second(i) - alpha) < NT(1e-08))
+        {
+            found_positive_alpha = true;
+        }
+    }
+
+    CHECK(found_negative_alpha);
+    CHECK(found_positive_alpha);
+}

--- a/test/simplexintersectball_test.cpp
+++ b/test/simplexintersectball_test.cpp
@@ -169,6 +169,32 @@ TEST_CASE("simplexintersectball_3d_tetrahedron_gc_intersection")
     CHECK(interval.second == doctest::Approx(-alpha));
 }
 
+TEST_CASE("simplexintersectball_3d_tetrahedron_gc_intersection_positive")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    NT inv_sqrt3 = NT(1) / std::sqrt(NT(3));
+    NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
+
+    VT r_vec(3);
+    r_vec << inv_sqrt3, inv_sqrt3, inv_sqrt3;
+    Point r(r_vec);
+
+    VT v_vec(3);
+    v_vec << inv_sqrt2, -inv_sqrt2, 0;
+    Point v(v_vec);
+
+    VT Ar;
+    VT Av;
+
+    std::pair<NT, int> hit = K.gc_intersect_positive(r, v, Ar, Av);
+
+    NT alpha = std::atan(std::sqrt(NT(2) / NT(3)));
+
+    CHECK(hit.first == doctest::Approx(alpha));
+    CHECK(hit.second == 1);
+}
+
 TEST_CASE("simplexintersectball_3d_tetrahedron_reflection")
 {
     SimplexBall K = make_3d_tetrahedron_unit_ball();

--- a/test/simplexintersectball_test.cpp
+++ b/test/simplexintersectball_test.cpp
@@ -1,0 +1,92 @@
+#include "doctest.h"
+
+#include <Eigen/Eigen>
+
+#include "convex_bodies/simplexintersectball.h"
+#include "cartesian_geom/cartesian_kernel.h"
+
+typedef double NT;
+typedef Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> MT;
+typedef Eigen::Matrix<NT, Eigen::Dynamic, 1> VT;
+typedef Cartesian<NT> Kernel;
+typedef typename Kernel::Point Point;
+typedef SimplexIntersectBall<Point> SimplexBall;
+
+TEST_CASE("simplexintersectball_basic_membership")
+{
+    unsigned int d = 2;
+
+    // Simplex in R^2:
+    // x >= 0, y >= 0, x + y <= 1
+    MT A(3, 2);
+    A << -1,  0,
+          0, -1,
+          1,  1;
+
+    VT b(3);
+    b << 0, 0, 1;
+
+    // Vertices stored column-wise: (0,0), (1,0), (0,1)
+    MT V(2, 3);
+    V << 0, 1, 0,
+         0, 0, 1;
+
+    VT x0(2);
+    x0 << 0, 0;
+
+    SimplexBall K(d, A, b, V, x0);
+
+    CHECK(K.dimension() == 2);
+    CHECK(K.num_of_hyperplanes() == 3);
+
+    VT inside_vec(2);
+    inside_vec << 0.2, 0.2;
+    Point inside(inside_vec);
+
+    VT outside_simplex_vec(2);
+    outside_simplex_vec << 0.8, 0.8;
+    Point outside_simplex(outside_simplex_vec);
+
+    VT outside_ball_vec(2);
+    outside_ball_vec << 1.2, 0.0;
+    Point outside_ball(outside_ball_vec);
+
+    CHECK(K.is_in(inside) == -1);
+    CHECK(K.is_in(outside_simplex) == 0);
+    CHECK(K.is_in(outside_ball) == 0);
+}
+
+TEST_CASE("simplexintersectball_line_intersection")
+{
+    unsigned int d = 2;
+
+    MT A(3, 2);
+    A << -1,  0,
+          0, -1,
+          1,  1;
+
+    VT b(3);
+    b << 0, 0, 1;
+
+    MT V(2, 3);
+    V << 0, 1, 0,
+         0, 0, 1;
+
+    VT x0(2);
+    x0 << 0, 0;
+
+    SimplexBall K(d, A, b, V, x0);
+
+    VT r_vec(2);
+    r_vec << 0.2, 0.2;
+    Point r(r_vec);
+
+    VT v_vec(2);
+    v_vec << 1.0, 0.0;
+    Point v(v_vec);
+
+    std::pair<NT, NT> interval = K.line_intersect(r, v);
+
+    CHECK(interval.first == doctest::Approx(0.6));
+    CHECK(interval.second == doctest::Approx(-0.2));
+}

--- a/test/simplexintersectball_test.cpp
+++ b/test/simplexintersectball_test.cpp
@@ -12,6 +12,34 @@ typedef Cartesian<NT> Kernel;
 typedef typename Kernel::Point Point;
 typedef SimplexIntersectBall<Point> SimplexBall;
 
+SimplexBall make_3d_tetrahedron_unit_ball()
+{
+    unsigned int d = 3;
+
+    // Tetrahedron in R^3:
+    // x >= 0, y >= 0, z >= 0, x + y + z <= 2
+    MT A(4, 3);
+    A << -1,  0,  0,
+          0, -1,  0,
+          0,  0, -1,
+          1,  1,  1;
+
+    VT b(4);
+    b << 0, 0, 0, 2;
+
+    // Vertices stored column-wise:
+    // (0,0,0), (2,0,0), (0,2,0), (0,0,2)
+    MT V(3, 4);
+    V << 0, 2, 0, 0,
+         0, 0, 2, 0,
+         0, 0, 0, 2;
+
+    VT x0(3);
+    x0 << 0, 0, 0;
+
+    return SimplexBall(d, A, b, V, x0);
+}
+
 TEST_CASE("simplexintersectball_basic_membership")
 {
     unsigned int d = 2;
@@ -89,4 +117,79 @@ TEST_CASE("simplexintersectball_line_intersection")
 
     CHECK(interval.first == doctest::Approx(0.6));
     CHECK(interval.second == doctest::Approx(-0.2));
+}
+
+TEST_CASE("simplexintersectball_3d_tetrahedron_membership")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    CHECK(K.dimension() == 3);
+    CHECK(K.num_of_hyperplanes() == 4);
+
+    VT inside_vec(3);
+    inside_vec << 0.3, 0.3, 0.3;
+    Point inside(inside_vec);
+
+    VT outside_simplex_vec(3);
+    outside_simplex_vec << -0.1, 0.2, 0.2;
+    Point outside_simplex(outside_simplex_vec);
+
+    VT outside_ball_vec(3);
+    outside_ball_vec << 1.2, 0.0, 0.0;
+    Point outside_ball(outside_ball_vec);
+
+    CHECK(K.is_in(inside) == -1);
+    CHECK(K.is_in(outside_simplex) == 0);
+    CHECK(K.is_in(outside_ball) == 0);
+}
+
+TEST_CASE("simplexintersectball_3d_tetrahedron_gc_intersection")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    NT inv_sqrt3 = NT(1) / std::sqrt(NT(3));
+    NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
+
+    VT r_vec(3);
+    r_vec << inv_sqrt3, inv_sqrt3, inv_sqrt3;
+    Point r(r_vec);
+
+    VT v_vec(3);
+    v_vec << inv_sqrt2, -inv_sqrt2, 0;
+    Point v(v_vec);
+
+    VT Ar;
+    VT Av;
+
+    std::pair<NT, NT> interval = K.gc_intersect(r, v, Ar, Av);
+
+    NT alpha = std::atan(std::sqrt(NT(2) / NT(3)));
+
+    CHECK(interval.first == doctest::Approx(alpha));
+    CHECK(interval.second == doctest::Approx(-alpha));
+}
+
+TEST_CASE("simplexintersectball_3d_tetrahedron_reflection")
+{
+    SimplexBall K = make_3d_tetrahedron_unit_ball();
+
+    NT inv_sqrt2 = NT(1) / std::sqrt(NT(2));
+
+    // Point on the unit sphere and on the facet y = 0
+    VT p(3);
+    p << inv_sqrt2, 0, inv_sqrt2;
+
+    // Tangent direction pointing outside through y < 0
+    VT v(3);
+    v << 0, -1, 0;
+
+    MT projector = MT::Identity(3, 3) - p * p.transpose();
+
+    int facet = 1; // y = 0 facet, represented by -y <= 0
+
+    K.compute_reflection(v, p, projector, facet);
+
+    CHECK(v(0) == doctest::Approx(0.0));
+    CHECK(v(1) == doctest::Approx(1.0));
+    CHECK(v(2) == doctest::Approx(0.0));
 }


### PR DESCRIPTION
Adds utilities for identifying connected components of the simplex-sphere intersection and computing starting points for each component.

Main changes:
- Build graph over active simplex vertices outside the ball.
- Find connected components corresponding to simplex-ball spherical patches.
- Compute starting points by intersecting rays from an interior point with the sphere.
- Add approximate Chebyshev center helper for Δ ∩ B using lp_solve and cutting-plane linearization of the ball constraint.
- Add tests for segment-ball intersections, component detection, starting points, isolated active vertices, Chebyshev center, and the turnkey Chebyshev-based wrapper.

Tests:
- ./build/simplexintersectball_components_test
- ctest -R simplexball_components --output-on-failure