### PR TITLE
Fix Gaussian exact HMC MMCS interface 

### DIFF
--- a/include/random_walks/gaussian_hamiltonian_monte_carlo_exact_walk.hpp
+++ b/include/random_walks/gaussian_hamiltonian_monte_carlo_exact_walk.hpp
@@ -16,28 +16,30 @@
 
 struct GaussianHamiltonianMonteCarloExactWalk
 {
-    GaussianHamiltonianMonteCarloExactWalk(double L, unsigned int _rho)
-            :   param(L, true, _rho, true)
+    GaussianHamiltonianMonteCarloExactWalk(double L, unsigned int _rho, double a = 1.0)
+            :   param(L, true, _rho, true, a)
     {}
 
     GaussianHamiltonianMonteCarloExactWalk(double L)
-            :   param(L, true, 0, false)
+            :   param(L, true, 0, false, 1.0)
     {}
 
     GaussianHamiltonianMonteCarloExactWalk()
-            :   param(0, false, 0, false)
+            :   param(0, false, 0, false, 1.0)
     {}
 
 
     struct parameters
     {
-        parameters(double L, bool set, unsigned int _rho, bool _set_rho)
-                :   m_L(L), set_L(set), rho(_rho), set_rho(_set_rho)
+        parameters(double L, bool set, unsigned int _rho, bool _set_rho,
+                   double _a = 1.0)
+                :   m_L(L), set_L(set), rho(_rho), set_rho(_set_rho), a(_a)
         {}
         double m_L;
         bool set_L;
         unsigned int rho;
         bool set_rho;
+        double a;
     };
 
     parameters param;
@@ -60,9 +62,9 @@ struct Walk
     {
         _Len = compute_diameter<GenericPolytope>
                 ::template compute<NT>(P);
-        _omega = std::sqrt(NT(2) * a_i);
+        set_omega(a_i);
         _rho = 100 * P.dimension(); // upper bound for the number of reflections (experimental)
-        initialize(P, p, a_i, rng);
+        initialize(P, p, rng);
     }
 
     template <typename GenericPolytope>
@@ -72,9 +74,21 @@ struct Walk
         _Len = params.set_L ? params.m_L
                           : compute_diameter<GenericPolytope>
                             ::template compute<NT>(P);
-        _omega = std::sqrt(NT(2) * a_i);
-        _rho = 100 * P.dimension(); // upper bound for the number of reflections (experimental)
-        initialize(P, p, a_i, rng);
+        set_omega(a_i);
+        _rho = params.set_rho ? params.rho : 100 * P.dimension(); // upper bound for the number of reflections (experimental)
+        initialize(P, p, rng);
+    }
+
+    template <typename GenericPolytope>
+    Walk(GenericPolytope &P, Point const& p, RandomNumberGenerator &rng,
+         parameters const& params)
+    {
+        _Len = params.set_L ? params.m_L
+                          : compute_diameter<GenericPolytope>
+                            ::template compute<NT>(P);
+        set_omega(static_cast<NT>(params.a));
+        _rho = params.set_rho ? params.rho : 100 * P.dimension(); // upper bound for the number of reflections (experimental)
+        initialize(P, p, rng);
     }
 
     template
@@ -83,7 +97,6 @@ struct Walk
     >
     inline void apply(GenericPolytope const& P,
                       Point& p,
-                      NT const& a_i,
                       unsigned int const& walk_length,
                       RandomNumberGenerator &rng)
     {
@@ -118,6 +131,20 @@ struct Walk
             }
         }
         p = _p;
+    }
+
+    template
+    <
+        typename GenericPolytope
+    >
+    inline void apply(GenericPolytope const& P,
+                      Point& p,
+                      NT const& a_i,
+                      unsigned int const& walk_length,
+                      RandomNumberGenerator &rng)
+    {
+        set_omega(a_i);
+        apply(P, p, walk_length, rng);
     }
 
 
@@ -192,13 +219,18 @@ struct Walk
 
 private :
 
+    inline void set_omega(NT const& a_i)
+    {
+        NT aa = (a_i > NT(0)) ? a_i : NT(1);
+        _omega = std::sqrt(NT(2) * aa);
+    }
+
     template
     <
         typename GenericPolytope
     >
     inline void initialize(GenericPolytope const& P,
                            Point const& p,
-                           NT const& a_i,
                            RandomNumberGenerator &rng)
     {
         unsigned int n = P.dimension();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -219,6 +219,7 @@ add_test(NAME test_bcdhr COMMAND sampling_test -tc=bcdhr)
 add_test(NAME test_grdhr COMMAND sampling_test -tc=grdhr)
 add_test(NAME test_gbaw COMMAND sampling_test -tc=gbaw)
 add_test(NAME test_ghmc COMMAND sampling_test -tc=ghmc)
+add_test(NAME test_ghmc_mmcs_interface COMMAND sampling_test -tc=ghmc_mmcs_interface)
 add_test(NAME test_gabw COMMAND sampling_test -tc=gabw)
 add_test(NAME test_sparse COMMAND sampling_test -tc=sparse)
 

--- a/test/sampling_test.cpp
+++ b/test/sampling_test.cpp
@@ -25,6 +25,7 @@
 #include "volume/volume_sequence_of_balls.hpp"
 #include "generators/known_polytope_generators.h"
 #include "sampling/sampling.hpp"
+#include "sampling/mmcs.hpp"
 
 #include "diagnostics/univariate_psrf.hpp"
 
@@ -304,6 +305,42 @@ void call_test_ghmc(){
     CHECK(score.maxCoeff() < 2.2);
 }
 
+template <typename NT>
+void call_test_ghmc_mmcs_interface()
+{
+    typedef Cartesian<NT>    Kernel;
+    typedef typename Kernel::Point    Point;
+    typedef HPolytope<Point> Hpolytope;
+    typedef Eigen::Matrix<NT,Eigen::Dynamic,Eigen::Dynamic> MT;
+    typedef BoostRandomNumberGenerator<boost::mt19937, NT, 3> RNGType;
+    typedef GaussianHamiltonianMonteCarloExactWalk WalkTypePolicy;
+    typedef typename WalkTypePolicy::template Walk<Hpolytope, RNGType> Walk;
+
+    unsigned int d = 3;
+    std::cout << "--- Testing Gaussian exact HMC MMCS interface for H-cube3" << std::endl;
+    Hpolytope P = generate_cube<Hpolytope>(d, false);
+    P.ComputeInnerBall();
+
+    RNGType rng(d);
+    Point p = P.InnerBall().first;
+    WalkTypePolicy WalkType;
+    Walk walk(P, p, rng, WalkType.param);
+
+    walk.parameters_burnin(P, p, 5, 3, rng);
+    Point q(d);
+    walk.get_starting_point(P, p, q, 3, rng);
+    walk.apply(P, q, 1, rng);
+    CHECK(q.getCoefficients().allFinite());
+    CHECK(P.is_in(q, NT(1e-6)) < 0);
+
+    unsigned int Neff_sampled = 0, total_samples = 0;
+    MT TotalRandPoints;
+    perform_mmcs_step(P, rng, 1u, 1u, 20u, 20u, Neff_sampled, total_samples,
+                      20u, TotalRandPoints, p, 1u, false, WalkType);
+    CHECK(total_samples >= 20u);
+    CHECK(TotalRandPoints.allFinite());
+}
+
 template <typename NT, typename WalkType = GaussianAcceleratedBilliardWalk>
 void call_test_gabw(){
     typedef Cartesian<NT>    Kernel;
@@ -491,6 +528,10 @@ TEST_CASE("gbaw") {
 
 TEST_CASE("ghmc") {
     call_test_ghmc<double>();
+}
+
+TEST_CASE("ghmc_mmcs_interface") {
+    call_test_ghmc_mmcs_interface<double>();
 }
 
 TEST_CASE("gabw") {


### PR DESCRIPTION
Fixes #459.

MMCS constructs Walk(P, p, rng, params) and calls apply without a_i. Gaussian exact HMC only had the a_i versions, so it didn't compile. I added the missing overloads. The Gaussian variance parameter is on WalkType.param.a (default 1); gaussian_sampling still passes a_i as before. The test is a 3D cube that hits those calls and perform_mmcs_step.